### PR TITLE
Add Ability to Write/Use st2.secrets.conf from K8s Secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
 * Initialize basic unittest infrastructure using `helm-unittest`. Added tests for custom annotations. (#284)
+* New Feature: Add `existingConfigSecret` .  If this is defined, the `st2.secrets.conf` key within this secret will be written as /etc/st2/st2.secrets.conf and added to the end of the command line arguments of all pods. (#289) (by @eric-al)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -93,11 +93,31 @@ Reduce duplication of the st2.*.conf volume details
 - name: st2-config-vol
   mountPath: /etc/st2/st2.user.conf
   subPath: st2.user.conf
+{{- if $.Values.st2.existingConfigSecret }}
+- name: st2-config-secrets-vol
+  mountPath: /etc/st2/st2.secrets.conf
+  subPath: st2.secrets.conf
+{{- end }}
 {{- end -}}
 {{- define "stackstorm-ha.st2-config-volume" -}}
 - name: st2-config-vol
   configMap:
     name: {{ $.Release.Name }}-st2-config
+{{- if $.Values.st2.existingConfigSecret }}
+- name: st2-config-secrets-vol
+  secret:
+    secretName: {{ $.Values.st2.existingConfigSecret }}
+{{- end }}
+{{- end -}}
+
+# Override CMD CLI parameters passed to the startup of all pods to add support for /etc/st2/st2.secrets.conf
+{{- define "st2-config-file-parameters" -}}
+- --config-file=/etc/st2/st2.conf
+- --config-file=/etc/st2/st2.docker.conf
+- --config-file=/etc/st2/st2.user.conf
+{{- if $.Values.st2.existingConfigSecret }}
+- --config-file=/etc/st2/st2.secrets.conf
+{{- end }}
 {{- end -}}
 
 {{- define "stackstorm-ha.init-containers-wait-for-db" -}}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -13,7 +13,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  # TODO: Bundle DB/MQ login secrets in dynamic ENV-based st2.secrets.conf, leave custom user-defined settings for st2.user.conf (?)
   # Docker/K8s-based st2 config file used for templating service names and common overrides on top of original st2.conf.
   # The order of merging: st2.conf < st2.docker.conf < st2.user.conf
   st2.docker.conf: |

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -83,6 +83,9 @@ spec:
         {{- end }}
         ports:
         - containerPort: 9100
+        command:
+          - /opt/stackstorm/st2/bin/st2auth
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -213,6 +216,9 @@ spec:
         {{- end }}
         ports:
         - containerPort: 9101
+        command:
+          - /opt/stackstorm/st2/bin/st2api
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -350,6 +356,9 @@ spec:
         {{- end }}
         ports:
         - containerPort: 9102
+        command:
+          - /opt/stackstorm/st2/bin/st2stream
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -605,6 +614,9 @@ spec:
       - name: st2rulesengine
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /opt/stackstorm/st2/bin/st2rulesengine
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -733,6 +745,9 @@ spec:
       - name: st2timersengine
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /opt/stackstorm/st2/bin/st2timersengine
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -848,6 +863,10 @@ spec:
       - name: st2workflowengine
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /opt/stackstorm/st2/bin/st2workflowengine
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
+        # TODO: Add liveness/readiness probes (#3)
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -975,6 +994,9 @@ spec:
       - name: st2scheduler
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /opt/stackstorm/st2/bin/st2scheduler
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -1102,6 +1124,9 @@ spec:
       - name: st2notifier
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /opt/stackstorm/st2/bin/st2notifier
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -1255,12 +1280,10 @@ spec:
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if $one_sensor_per_pod }}
         command:
           - /opt/stackstorm/st2/bin/st2sensorcontainer
-          - --config-file=/etc/st2/st2.conf
-          - --config-file=/etc/st2/st2.docker.conf
-          - --config-file=/etc/st2/st2.user.conf
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
+        {{- if $one_sensor_per_pod }}
           - --single-sensor-mode
           - --sensor-ref={{ required "You must define `ref` for everything in st2.packs.sensors. This assigns each sensor to a pod." $sensor.ref }}
         {{- end }}
@@ -1405,6 +1428,9 @@ spec:
       - name: st2actionrunner
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /opt/stackstorm/st2/bin/st2actionrunner
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
         {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -1550,6 +1576,9 @@ spec:
       - name: st2garbagecollector
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - /opt/stackstorm/st2/bin/st2garbagecollector
+        {{- include "st2-config-file-parameters" $ | nindent 10 }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -51,9 +51,7 @@ spec:
         command:
           - st2-apply-rbac-definitions
           - --verbose
-          - --config-file=/etc/st2/st2.conf
-          - --config-file=/etc/st2/st2.docker.conf
-          - --config-file=/etc/st2/st2.user.conf
+          {{- include "st2-config-file-parameters" . | nindent 10 }}
         {{- if .Values.jobs.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.jobs | nindent 8 }}
         {{- end }}
@@ -458,9 +456,7 @@ spec:
         {{- end }}
         command:
           - st2-register-content
-          - --config-file=/etc/st2/st2.conf
-          - --config-file=/etc/st2/st2.docker.conf
-          - --config-file=/etc/st2/st2.user.conf
+          {{- include "st2-config-file-parameters" . | nindent 10 }}
           - --register-all
           - --register-fail-on-failure
         {{- if .Values.jobs.env }}

--- a/values.yaml
+++ b/values.yaml
@@ -68,6 +68,12 @@ st2:
     [api]
     allow_origin = '*'
 
+  # Custom StackStorm config (st2.secret.conf) which will be created from the key 'st2.secret.conf' within this secret.
+  # If this is defined, '--config-file=/etc/st2/st2.secrets.conf' will be added to the end of the command line arguments 
+  # for all pods, superseding all other configuration values.
+  # This secret must be populated outside of this chart.
+  # existingConfigSecret: stackstorm-config-secret
+
   # This mirrors the [system_user] section of st2.conf, but makes the values available for helm templating.
   # If you change the user, you must provide a customized st2actionrunner image that includes your user.
   system_user:
@@ -893,7 +899,7 @@ mongodb:
     rootPassword: "8fAzdnksdzPFUWm4a68EfY7nMhBPaa"
     # Initial database for stackstorm
     database: "st2"
-    # Minimal key length is 6 symbols
+    # Minimal key length is 6 symbols and may only contain characters in the base64 set.
     replicaSetKey: "82PItDpqroti5RngOA7UqbHH7c6bFUwy"
     # Whether to enable the arbiter
   arbiter:


### PR DESCRIPTION
This PR adds the capability to define '/etc/st2/st2.secret.conf' in a Kubernetes secret.  No longer will users need things like helm-secrets to safely store secret values that ultimately wind up in /etc/st2/*.conf.

If this is defined, the contents of key 'st2.secret.conf' within the defined secret name will be written to '/etc/st2/st2.secret.conf' on all pods.  In addition, '--config-file=/etc/st2/st2.secrets.conf' will be added to the end of the command line arguments for all pods, superseding all other configuration values.

This addresses the Comment-Based-TODO here:  https://github.com/alertlogic/stackstorm-ha/blob/master/templates/configmaps_st2-conf.yaml#L16