### PR TITLE
Ingress api version deprecation support for k8s v.1.22. fixes #277

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In Development
 * Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312 #318) (by @0xhaven)
 * Refactor label definitions to be more consistent by building labels and label selectors in partial helper templates. (#299) (by @cognifloyd)
+* Use the correct `apiVersion` for `Ingress` to add support for Kubernetes `v1.22`. (by @arms11)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.ingress.enabled }}
 ---
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-st2web-ingress
@@ -26,9 +30,18 @@ spec:
       paths:
       {{- range .paths }}
         - path: {{ default "/*" .path }}
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .serviceName }}
+              port:
+                number: {{ .servicePort }}
+          {{- else }}
           backend:
             serviceName: {{ .serviceName }}
             servicePort: {{ .servicePort }}
+          {{- end }}
       {{- end }}
   {{- else }}
     {{- if required "Missing context '.Values.st2web.service.hostname'!" .Values.st2web.service.hostname }}
@@ -37,9 +50,18 @@ spec:
     http:
       paths:
         - path: "/"
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Release.Name }}-st2web
+              port:
+                number: 80
+          {{- else }}
           backend:
             serviceName: {{ .Release.Name }}-st2web
             servicePort: 80
+          {{- end }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
       paths:
       {{- range .paths }}
         - path: {{ default "/*" .path }}
-          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
           pathType: Prefix
           backend:
             service:

--- a/tests/unit/ingress_test.yaml
+++ b/tests/unit/ingress_test.yaml
@@ -1,0 +1,192 @@
+---
+suite: Ingress
+templates:
+  # primary template files
+  - ingress.yaml
+
+tests:
+  - it: Ingress not present if disabled
+    set:
+      ingress:
+        enabled: false 
+    asserts:
+      - hasDocuments:
+          count: 0
+  
+  - it: Ingress is present when enabled without hosts (older k8s)
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    set:
+      ingress:
+        enabled: true
+        hosts: []
+        tls: []
+      st2web:
+        service:
+          hostname: &st2web_hostname some-host-name
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Ingress
+      # no ingress.hosts, so only st2web.hostname
+      - equal: &st2web_rules_host
+          path: spec.rules[0].host
+          value: *st2web_hostname
+      - contains: &one_host_path
+          path: spec.rules[0].http.paths
+          count: 1
+      - equal: &host_path_is_root
+          path: spec.rules[0].http.paths[0].path
+          value: "/"
+      - isNull:
+          path: spec.rules[0].http.paths[0].pathType
+      - equal:
+          path: spec.rules[0].http.paths[0].backend
+          value:
+            serviceName: st2ha-st2web
+            servicePort: 80
+
+  - it: Ingress is present when enabled without hosts (newer k8s)
+    capabilities:
+      # introduced in 1.19, stable in 1.22
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      ingress:
+        enabled: true
+        hosts: []
+        tls: []
+      st2web:
+        service:
+          hostname: some-host-name
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Ingress
+      # no ingress.hosts, so only st2web.hostname
+      - equal: *st2web_rules_host
+      - contains: *one_host_path
+      - equal: *host_path_is_root
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Preix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend
+          value:
+            service:
+              name: st2ha-st2web
+              port:
+                number: 80
+
+  - it: Ingress is present when enabled with hosts (older k8s)
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    set:
+      ingress:
+        enabled: true
+        hosts: &hosts
+          - host: hostname.domain.tld
+            paths:
+              - serviceName: st2ha-st2web
+                servicePort: 80
+              - path: /fancy-sensor
+                serviceName: fancy-sensor
+                servicePort: 8080
+        tls: []
+      st2web:
+        service:
+          hostname: *st2web_hostname
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Ingress
+      # no ingress.hosts, so only st2web.hostname
+      - equal: *st2web_rules_host
+      - contains: &two_host_paths
+          path: spec.rules[0].http.paths
+          count: 2
+      - equal: &host_path_is_root_glob
+          path: spec.rules[0].http.paths[0].path
+          value: "/*"
+      - isNull:
+          path: spec.rules[0].http.paths[0].pathType
+      - equal:
+          path: spec.rules[0].http.paths[0].backend
+          value:
+            serviceName: st2ha-st2web
+            servicePort: 80
+
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: "/fancy-sensor"
+      - isNull:
+          path: spec.rules[0].http.paths[1].pathType
+      - equal:
+          path: spec.rules[0].http.paths[1].backend
+          value:
+            serviceName: fancy-sensor
+            servicePort: 8080
+
+  - it: Ingress is present when enabled with hosts (newer k8s)
+    capabilities:
+      # introduced in 1.19, stable in 1.22
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      ingress:
+        enabled: true
+        hosts: *hosts
+        tls: []
+      st2web:
+        service:
+          hostname: some-host-name
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Ingress
+      # no ingress.hosts, so only st2web.hostname
+      - equal: *st2web_rules_host
+      - contains: *two_host_paths
+      - equal: *host_path_is_root_glob
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Preix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend
+          value:
+            service:
+              name: st2ha-st2web
+              port:
+                number: 80
+
+      - equal:
+          path: spec.rules[0].http.paths[1].path
+          value: "/fancy-sensor"
+      - equal:
+          path: spec.rules[0].http.paths[1].pathType
+          value: Preix
+      - equal:
+          path: spec.rules[0].http.paths[1].backend
+          value:
+            service:
+              name: fancy-sensor
+              port:
+                number: 8080

--- a/tests/unit/ingress_test.yaml
+++ b/tests/unit/ingress_test.yaml
@@ -37,19 +37,16 @@ tests:
       - equal: &st2web_rules_host
           path: spec.rules[0].host
           value: *st2web_hostname
-      - contains: &one_host_path
+      - contains:
           path: spec.rules[0].http.paths
           count: 1
-      - equal: &host_path_is_root
-          path: spec.rules[0].http.paths[0].path
-          value: "/"
+          content:
+            path: "/"
+            backend:
+              serviceName: st2ha-st2web
+              servicePort: 80
       - isNull:
           path: spec.rules[0].http.paths[0].pathType
-      - equal:
-          path: spec.rules[0].http.paths[0].backend
-          value:
-            serviceName: st2ha-st2web
-            servicePort: 80
 
   - it: Ingress is present when enabled without hosts (newer k8s)
     capabilities:
@@ -74,18 +71,17 @@ tests:
           value: Ingress
       # no ingress.hosts, so only st2web.hostname
       - equal: *st2web_rules_host
-      - contains: *one_host_path
-      - equal: *host_path_is_root
-      - equal:
-          path: spec.rules[0].http.paths[0].pathType
-          value: Preix
-      - equal:
-          path: spec.rules[0].http.paths[0].backend
-          value:
-            service:
-              name: st2ha-st2web
-              port:
-                number: 80
+      - contains:
+          path: spec.rules[0].http.paths
+          count: 1
+          content:
+            path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: st2ha-st2web
+                port:
+                  number: 80
 
   - it: Ingress is present when enabled with hosts (older k8s)
     capabilities:
@@ -116,9 +112,6 @@ tests:
           value: Ingress
       # no ingress.hosts, so only st2web.hostname
       - equal: *st2web_rules_host
-      - contains: &two_host_paths
-          path: spec.rules[0].http.paths
-          count: 2
       - equal: &host_path_is_root_glob
           path: spec.rules[0].http.paths[0].path
           value: "/*"
@@ -164,7 +157,6 @@ tests:
           value: Ingress
       # no ingress.hosts, so only st2web.hostname
       - equal: *st2web_rules_host
-      - contains: *two_host_paths
       - equal: *host_path_is_root_glob
       - equal:
           path: spec.rules[0].http.paths[0].pathType

--- a/tests/unit/ingress_test.yaml
+++ b/tests/unit/ingress_test.yaml
@@ -12,11 +12,13 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  
+
   - it: Ingress is present when enabled without hosts (older k8s)
-    capabilities:
+    capabilities: &cap_older
       majorVersion: 1
       minorVersion: 18
+      apiVersions:
+        - networking.k8s.io/v1beta1
     set:
       ingress:
         enabled: true
@@ -24,7 +26,7 @@ tests:
         tls: []
       st2web:
         service:
-          hostname: &st2web_hostname some-host-name
+          hostname: &st2web_hostname hostname.domain.tld
     release:
       name: st2ha
     asserts:
@@ -49,10 +51,12 @@ tests:
           path: spec.rules[0].http.paths[0].pathType
 
   - it: Ingress is present when enabled without hosts (newer k8s)
-    capabilities:
-      # introduced in 1.19, stable in 1.22
+    capabilities: &cap_newer
       majorVersion: 1
       minorVersion: 19
+      apiVersions:
+        - networking.k8s.io/v1 # introduced in 1.19, stable in 1.22
+        - networking.k8s.io/v1beta1
     set:
       ingress:
         enabled: true
@@ -60,7 +64,7 @@ tests:
         tls: []
       st2web:
         service:
-          hostname: some-host-name
+          hostname: *st2web_hostname
     release:
       name: st2ha
     asserts:
@@ -84,14 +88,12 @@ tests:
                   number: 80
 
   - it: Ingress is present when enabled with hosts (older k8s)
-    capabilities:
-      majorVersion: 1
-      minorVersion: 18
+    capabilities: *cap_older
     set:
       ingress:
         enabled: true
         hosts: &hosts
-          - host: hostname.domain.tld
+          - host: *st2web_hostname
             paths:
               - serviceName: st2ha-st2web
                 servicePort: 80
@@ -135,10 +137,7 @@ tests:
             servicePort: 8080
 
   - it: Ingress is present when enabled with hosts (newer k8s)
-    capabilities:
-      # introduced in 1.19, stable in 1.22
-      majorVersion: 1
-      minorVersion: 19
+    capabilities: *cap_newer
     set:
       ingress:
         enabled: true
@@ -146,7 +145,7 @@ tests:
         tls: []
       st2web:
         service:
-          hostname: some-host-name
+          hostname: *st2web_hostname
     release:
       name: st2ha
     asserts:
@@ -160,7 +159,7 @@ tests:
       - equal: *host_path_is_root_glob
       - equal:
           path: spec.rules[0].http.paths[0].pathType
-          value: Preix
+          value: Prefix
       - equal:
           path: spec.rules[0].http.paths[0].backend
           value:
@@ -174,7 +173,7 @@ tests:
           value: "/fancy-sensor"
       - equal:
           path: spec.rules[0].http.paths[1].pathType
-          value: Preix
+          value: Prefix
       - equal:
           path: spec.rules[0].http.paths[1].backend
           value:


### PR DESCRIPTION
`Ingress.yaml` uses correct `apiVersion` and related `spec` changes that are now required starting version `v1.22` of `kubernetes`.