### PR TITLE
Add custom pypi feature

### DIFF
--- a/conf/pip.conf
+++ b/conf/pip.conf
@@ -1,0 +1,4 @@
+[global]
+index-url = https://pypi.org/simple
+
+extra-index-url = {{ .Values.st2.customPyPiRepUrl }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -298,3 +298,26 @@ Create the custom env list for each deployment
   value: {{ $value | quote }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Define pypi volumeMounts
+*/}}
+{{- define "stackstorm-pypi-volume-mounts" -}}
+{{- if .Values.st2.customPyPiRepUrl }}
+- name: st2-custom-pip-conf
+  mountPath: /etc/pip.conf
+  subPath: pip.conf
+  readOnly: true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define pypi volumes
+*/}}
+{{- define "stackstorm-pypi-volume" -}}
+{{- if .Values.st2.customPyPiRepUrl }}
+- name: st2-custom-pip-conf
+  secret:
+    secretName: {{ .Release.Name }}-secrets-custom-pip-conf
+{{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -302,7 +302,7 @@ Create the custom env list for each deployment
 {{/*
 Define pypi volumeMounts
 */}}
-{{- define "stackstorm-pypi-volume-mounts" -}}
+{{- define "stackstorm-pypi-volume-mount" -}}
 {{- if .Values.st2.customPyPiRepUrl }}
 - name: st2-custom-pip-conf
   mountPath: /etc/pip.conf

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -224,6 +224,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-pypi-volume-mounts" . | nindent 8  }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -262,6 +263,7 @@ spec:
         {{- end }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
+        {{- include "stackstorm-pypi-volume" . | nindent 8  }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
         {{- end }}
@@ -1317,6 +1319,7 @@ spec:
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts" $ | nindent 8 }}
+        {{- include "stackstorm-pypi-volume-mounts" . | nindent 8  }}
         {{- if $some_sensors_per_pod }}
         - name: st2-sensor-config-vol
           mountPath: /etc/st2/st2.sensorcontainer.conf
@@ -1357,6 +1360,7 @@ spec:
         {{- end }}
         {{- include "stackstorm-ha.st2-config-volume" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" $ | nindent 8 }}
+        {{- include "stackstorm-pypi-volume" . | nindent 8  }}
         {{- if $some_sensors_per_pod }}
         - name: st2-sensor-config-vol
           emptyDir: # This is for a tiny file
@@ -1474,6 +1478,7 @@ spec:
         {{- end }}
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-pypi-volume-mounts" . | nindent 8  }}
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
@@ -1520,6 +1525,7 @@ spec:
               # 0400 file permission
               mode: 256
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
+        {{- include "stackstorm-pypi-volume" . | nindent 8  }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
         {{- end }}
@@ -1784,6 +1790,7 @@ spec:
         {{- end }}
         {{- include "stackstorm-ha.packs-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
+        {{- include "stackstorm-pypi-volume-mounts" . | nindent 8  }}
         {{- range .Values.st2client.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2client.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in st2client.extra_volumes" .mount | toYaml) $ | nindent 10 }}
@@ -1837,6 +1844,7 @@ spec:
               mode: 256
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
+        {{- include "stackstorm-pypi-volume" . | nindent 8  }}
         {{- range .Values.st2client.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2client.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in st2client.extra_volumes" .volume | toYaml) $ | nindent 10 }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -224,7 +224,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
-        {{- include "stackstorm-pypi-volume-mounts" . | nindent 8  }}
+        {{- include "stackstorm-pypi-volume-mount" . | nindent 8  }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -1319,7 +1319,7 @@ spec:
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts" $ | nindent 8 }}
-        {{- include "stackstorm-pypi-volume-mounts" . | nindent 8  }}
+        {{- include "stackstorm-pypi-volume-mount" $ | nindent 8  }}
         {{- if $some_sensors_per_pod }}
         - name: st2-sensor-config-vol
           mountPath: /etc/st2/st2.sensorcontainer.conf
@@ -1360,7 +1360,7 @@ spec:
         {{- end }}
         {{- include "stackstorm-ha.st2-config-volume" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" $ | nindent 8 }}
-        {{- include "stackstorm-pypi-volume" . | nindent 8  }}
+        {{- include "stackstorm-pypi-volume" $ | nindent 8  }}
         {{- if $some_sensors_per_pod }}
         - name: st2-sensor-config-vol
           emptyDir: # This is for a tiny file
@@ -1478,7 +1478,7 @@ spec:
         {{- end }}
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
-        {{- include "stackstorm-pypi-volume-mounts" . | nindent 8  }}
+        {{- include "stackstorm-pypi-volume-mount" . | nindent 8  }}
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
@@ -1790,7 +1790,7 @@ spec:
         {{- end }}
         {{- include "stackstorm-ha.packs-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
-        {{- include "stackstorm-pypi-volume-mounts" . | nindent 8  }}
+        {{- include "stackstorm-pypi-volume-mount" . | nindent 8  }}
         {{- range .Values.st2client.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2client.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in st2client.extra_volumes" .mount | toYaml) $ | nindent 10 }}

--- a/templates/secrets_pipconf.yaml
+++ b/templates/secrets_pipconf.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.st2.customPyPiRepUrl }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets-custom-pip-conf
+  labels:
+    app: st2
+    tier: backend
+    vendor: stackstorm
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  pip.conf: {{ tpl (.Files.Get "conf/pip.conf") . | b64enc }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -75,6 +75,14 @@ st2:
     # templating is allowed for this key
     ssh_key_file: "/home/{{ .Values.st2.system_user.user }}/.ssh/stanley_rsa"
 
+  ## This setting allows you to define a custom Pypi repo for use in stackstorm
+  #
+  # A list of pypi private repos you may have
+  # Example:
+  #  https://<user>:<pass>@<server>/<repository>/pypi/simple/
+  #
+  #customPyPiRepUrl: ""
+
   # Custom pack configs and image settings.
   #
   # By default, system packs are available. By default, however, `st2 pack install` cannot be run in the k8s cluster,


### PR DESCRIPTION
This feature allows the consumer to specify a custom pypi repository.

Use cases:
 - Air gapped installs
 - Shared volume pack installs that use a private repo.