### PR TITLE
Upgrade to MongoDB v4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Upgrade MongoDB `v4.0` -> `v4.4` as 4.0 has reached its EOL. (#304)
 
 ## v0.90.0
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)

--- a/values.yaml
+++ b/values.yaml
@@ -933,8 +933,8 @@ mongodb:
   # Specify your external [database] connection parameters under st2.config
   enabled: true
   image:
-    # StackStorm currently supports maximum MongoDB v4.0
-    tag: "4.0"
+    # StackStorm currently supports maximum MongoDB v4.4
+    tag: "4.4"
   # MongoDB architecture. Allowed values: standalone or replicaset
   architecture: replicaset
   # Name of the replica set


### PR DESCRIPTION
Per https://github.com/StackStorm/st2-packages/blob/75a0e5e06fc911c932da616aefac2065c4f38970/scripts/st2bootstrap-deb.sh#L494-L500 we support MongoDB max `v4.4` and according to https://github.com/StackStorm/st2/issues/5639#issuecomment-1117193721 `v4.0` EOL is in April 2022.

Bump MongoDB `v4.0` -> `v4.4`
