### PR TITLE
Issue #306 : Adding the ability to use overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Switch st2 to `v3.7` as a new default stable version (#274)
 * Upgrade MongoDB `v4.0` -> `v4.4` as 4.0 has reached its EOL. (#304)
 * Migrate from `python 3.6` `Ubuntu Bionic` to `python 3.8` `Ubuntu Focal` as a base StackStorm OS (StackStorm/st2-dockerfiles#54)
+* Add support for use of overrides that are available in `v3.7` of st2 via helm charts. (#306)
 
 ## v0.90.0
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -223,7 +223,7 @@ define this here as well to simplify comparison with packs-volume-mounts
   {{- if .Values.st2.overrides }}
 - name: st2-overrides-vol
   configMap:
-    name: {{ .Release.Name }}-st2-override-configs
+    name: {{ .Release.Name }}-st2-overrides-configs
   {{- end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -212,14 +212,14 @@ define this here as well to simplify comparison with packs-volume-mounts
 
 #Inserted for override ability to happen via helm charts
 
-{{- define "stackstorm-ha.override-config-mounts" -}}
+{{- define "stackstorm-ha.overrides-config-mounts" -}}
   {{- if .Values.st2.overrides }}
 - name: st2-overrides-vol
   mountPath: /opt/stackstorm/overrides/
   {{- end }}
 {{- end -}}
 
-{{- define "stackstorm-ha.override-configs" -}}
+{{- define "stackstorm-ha.overrides-configs" -}}
   {{- if .Values.st2.overrides }}
 - name: st2-overrides-vol
   configMap:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -220,7 +220,7 @@ define this here as well to simplify comparison with packs-volume-mounts
 {{- end -}}
 
 {{- define "stackstorm-ha.override-configs" -}}
-  {{- if .Values.st2.overrides.configs }}
+  {{- if .Values.st2.overrides }}
 - name: st2-overrides-vol
   configMap:
     name: {{ .Release.Name }}-st2-override-configs

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -210,6 +210,23 @@ define this here as well to simplify comparison with packs-volume-mounts
   {{- end }}
 {{- end -}}
 
+#Inserted for override ability to happen via helm charts
+
+{{- define "stackstorm-ha.override-config-mounts" -}}
+  {{- if .Values.st2.override.enabled }}
+- name: st2-overrides-vol
+  mountPath: /opt/stackstorm/overrides/
+  {{- end }}
+{{- end -}}
+
+{{- define "stackstorm-ha.override-configs" -}}
+  {{- if .Values.st2.override.enabled }}
+- name: st2-overrides-vol
+  configMap:
+    name: {{ .Release.Name }}-st2-override-configs
+  {{- end }}
+{{- end -}}
+
 {{/*
 For custom st2packs-initContainers reduce duplicity by defining them here once
 Merge packs and virtualenvs from st2 with those from st2packs images

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -213,14 +213,14 @@ define this here as well to simplify comparison with packs-volume-mounts
 #Inserted for override ability to happen via helm charts
 
 {{- define "stackstorm-ha.override-config-mounts" -}}
-  {{- if .Values.st2.override.enabled }}
+  {{- if .Values.st2.overrides.configs }}
 - name: st2-overrides-vol
   mountPath: /opt/stackstorm/overrides/
   {{- end }}
 {{- end -}}
 
 {{- define "stackstorm-ha.override-configs" -}}
-  {{- if .Values.st2.override.enabled }}
+  {{- if .Values.st2.overrides.configs }}
 - name: st2-overrides-vol
   configMap:
     name: {{ .Release.Name }}-st2-override-configs

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -213,7 +213,7 @@ define this here as well to simplify comparison with packs-volume-mounts
 #Inserted for override ability to happen via helm charts
 
 {{- define "stackstorm-ha.override-config-mounts" -}}
-  {{- if .Values.st2.overrides.configs }}
+  {{- if .Values.st2.overrides }}
 - name: st2-overrides-vol
   mountPath: /opt/stackstorm/overrides/
   {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -215,7 +215,7 @@ define this here as well to simplify comparison with packs-volume-mounts
 {{- define "stackstorm-ha.overrides-config-mounts" -}}
   {{- if .Values.st2.overrides }}
 - name: st2-overrides-vol
-  mountPath: /opt/stackstorm/overrides/
+  mountPath: /opt/stackstorm/overrides
   {{- end }}
 {{- end -}}
 

--- a/templates/configmaps_overrides.yaml
+++ b/templates/configmaps_overrides.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-st2-override-configs
+  name: {{ .Release.Name }}-st2-overrides-configs
   annotations:
     description: StackStorm override configs defined in helm values, shipped in (or copied to) '/opt/stackstorm/overrides'
   labels:

--- a/templates/configmaps_overrides.yaml
+++ b/templates/configmaps_overrides.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.st2.override.enabled }}
+{{- if .Values.st2.overrides.configs }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -14,5 +14,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{ toYaml .Values.st2.override.configs | indent 2 }}
+{{ toYaml .Values.st2.overrides.configs | indent 2 }}
 {{- end }}

--- a/templates/configmaps_overrides.yaml
+++ b/templates/configmaps_overrides.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.st2.override.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-st2-override-configs
+  annotations:
+    description: StackStorm override configs defined in helm values, shipped in (or copied to) '/opt/stackstorm/overrides'
+  labels:
+    app: st2
+    tier: backend
+    vendor: stackstorm
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{ toYaml .Values.st2.override.configs | indent 2 }}
+{{- end }}

--- a/templates/configmaps_overrides.yaml
+++ b/templates/configmaps_overrides.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.st2.overrides.configs }}
+{{- if .Values.st2.overrides }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -14,5 +14,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{ toYaml .Values.st2.overrides.configs | indent 2 }}
+{{ toYaml .Values.st2.overrides | indent 2 }}
 {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1774,7 +1774,7 @@ spec:
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
         {{- end }}
-        {{- if .Values.st2.override.enabled }}
+        {{- if .Values.st2.overrides.configs }}
         - name: st2-overrides-vol
           mountPath: /opt/stackstorm/overrides/
         {{- end }}
@@ -1829,7 +1829,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
         {{- end }}
-        {{- if .Values.st2.override.enabled }}
+        {{- if .Values.st2.overrides.configs }}
         - name: st2-overrides-vol
           configMap:
             name: {{ .Release.Name }}-st2-override-configs

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1774,7 +1774,7 @@ spec:
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
         {{- end }}
-        {{- if .Values.st2.overrides.configs }}
+        {{- if .Values.st2.overrides }}
         - name: st2-overrides-vol
           mountPath: /opt/stackstorm/overrides/
         {{- end }}
@@ -1829,7 +1829,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
         {{- end }}
-        {{- if .Values.st2.overrides.configs }}
+        {{- if .Values.st2.overrides }}
         - name: st2-overrides-vol
           configMap:
             name: {{ .Release.Name }}-st2-override-configs

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1776,7 +1776,7 @@ spec:
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
         {{- end }}
-        {{- include "stackstorm-ha.override-config-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.overrides-config-mounts" . | nindent 8 }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
@@ -1828,7 +1828,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
         {{- end }}
-        {{- include "stackstorm-ha.override-configs" . | nindent 8 }}
+        {{- include "stackstorm-ha.overrides-configs" . | nindent 8 }}
         - name: st2client-config-vol
           emptyDir:
             medium: Memory

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1818,9 +1818,6 @@ spec:
               path: datastore_key.json
         {{- end }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
-        - name: st2-overrides-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-override-configs
         {{- if .Values.st2.rbac.enabled }}
         - name: st2-rbac-roles-vol
           configMap:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1700,6 +1700,7 @@ spec:
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        checksum/overrides: {{ include (print $.Template.BasePath "/configmaps_overrides.yaml") . | sha256sum }}
         {{- if .Values.st2client.postStartScript }}
         checksum/post-start-script: {{ .Values.st2client.postStartScript | sha256sum }}
         {{- end }}
@@ -1773,6 +1774,10 @@ spec:
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
         {{- end }}
+        {{- if .Values.st2.override.enabled }}
+        - name: st2-overrides-vol
+          mountPath: /opt/stackstorm/overrides/
+        {{- end }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
@@ -1813,6 +1818,9 @@ spec:
               path: datastore_key.json
         {{- end }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
+        - name: st2-overrides-vol
+          configMap:
+            name: {{ .Release.Name }}-st2-override-configs
         {{- if .Values.st2.rbac.enabled }}
         - name: st2-rbac-roles-vol
           configMap:
@@ -1823,6 +1831,11 @@ spec:
         - name: st2-rbac-mappings-vol
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
+        {{- end }}
+        {{- if .Values.st2.override.enabled }}
+        - name: st2-overrides-vol
+          configMap:
+            name: {{ .Release.Name }}-st2-override-configs
         {{- end }}
         - name: st2client-config-vol
           emptyDir:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1700,7 +1700,9 @@ spec:
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- if .Values.st2.overrides }}
         checksum/overrides: {{ include (print $.Template.BasePath "/configmaps_overrides.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.st2client.postStartScript }}
         checksum/post-start-script: {{ .Values.st2client.postStartScript | sha256sum }}
         {{- end }}
@@ -1774,10 +1776,7 @@ spec:
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
         {{- end }}
-        {{- if .Values.st2.overrides }}
-        - name: st2-overrides-vol
-          mountPath: /opt/stackstorm/overrides/
-        {{- end }}
+        {{- include "stackstorm-ha.override-config-mounts" . | nindent 8 }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
@@ -1829,11 +1828,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
         {{- end }}
-        {{- if .Values.st2.overrides }}
-        - name: st2-overrides-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-override-configs
-        {{- end }}
+        {{- include "stackstorm-ha.override-configs" . | nindent 8 }}
         - name: st2client-config-vol
           emptyDir:
             medium: Memory

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -477,14 +477,14 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
-        {{- include "stackstorm-ha.override-config-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.overrides-config-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
-        {{- include "stackstorm-ha.override-configs" . | nindent 8 }}
+        {{- include "stackstorm-ha.overrides-configs" . | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
@@ -613,7 +613,7 @@ spec:
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
-        {{- include "stackstorm-ha.override-config-mounts" $ | nindent 8 }}
+        {{- include "stackstorm-ha.overrides-config-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" $ | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" $ | nindent 8 }}
@@ -624,7 +624,7 @@ spec:
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
-        {{- include "stackstorm-ha.override-configs" $ | nindent 8 }}
+        {{- include "stackstorm-ha.overrides-configs" $ | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" $ | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" $ | nindent 8 }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -416,7 +416,9 @@ spec:
         # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") . | sha256sum }}
+        {{- if .Values.st2.overrides }}
         checksum/overrides: {{ include (print $.Template.BasePath "/configmaps_overrides.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.jobs.annotations }}
           {{- toYaml .Values.jobs.annotations | nindent 8 }}
         {{- end }}
@@ -543,6 +545,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") $ | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") $ | sha256sum }}
+        {{- if $.Values.st2.overrides }}
+        checksum/overrides: {{ include (print $.Template.BasePath "/configmaps_overrides.yaml") $ | sha256sum }}
+        {{- end }}
         {{- if $.Values.jobs.annotations }}
           {{- toYaml $.Values.jobs.annotations | nindent 8 }}
         {{- end }}
@@ -608,6 +613,7 @@ spec:
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
+        {{- include "stackstorm-ha.override-config-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" $ | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" $ | nindent 8 }}
@@ -618,6 +624,7 @@ spec:
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
+        {{- include "stackstorm-ha.override-configs" $ | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" $ | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" $ | nindent 8 }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -416,6 +416,7 @@ spec:
         # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") . | sha256sum }}
+        checksum/overrides: {{ include (print $.Template.BasePath "/configmaps_overrides.yaml") . | sha256sum }}
         {{- if .Values.jobs.annotations }}
           {{- toYaml .Values.jobs.annotations | nindent 8 }}
         {{- end }}
@@ -474,12 +475,14 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.override-config-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
+        {{- include "stackstorm-ha.override-configs" . | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}

--- a/tests/unit/custom_annotations_test.yaml
+++ b/tests/unit/custom_annotations_test.yaml
@@ -9,6 +9,7 @@ templates:
   - services.yaml
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/dns_test.yaml
+++ b/tests/unit/dns_test.yaml
@@ -24,7 +24,7 @@ tests:
       - deployments.yaml
       - jobs.yaml
     set:
-      st2: 
+      st2:
         packs: { sensors: [] } # ensure only 1 sensor
         rbac: { enabled: true } # enable rbac job
       jobs:
@@ -55,7 +55,7 @@ tests:
           - name: ndots
             value: "2"
           - name: edns0
-      st2: 
+      st2:
         packs: { sensors: [] } # ensure only 1 sensor
         rbac: { enabled: true } # enable rbac job
       jobs:

--- a/tests/unit/dns_test.yaml
+++ b/tests/unit/dns_test.yaml
@@ -6,6 +6,7 @@ templates:
   - jobs.yaml
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/env_test.yaml
+++ b/tests/unit/env_test.yaml
@@ -6,6 +6,7 @@ templates:
   - jobs.yaml
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/image_pull_test.yaml
+++ b/tests/unit/image_pull_test.yaml
@@ -7,6 +7,7 @@ templates:
   - service-account.yaml
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/labels_test.yaml
+++ b/tests/unit/labels_test.yaml
@@ -5,6 +5,7 @@ templates:
   - jobs.yaml
   - services.yaml
 
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_post-start-scripts.yaml
   - configmaps_rbac.yaml

--- a/tests/unit/overrides_test.yaml
+++ b/tests/unit/overrides_test.yaml
@@ -1,0 +1,160 @@
+---
+suite: Override check
+templates:
+  # primary template files
+  - deployments.yaml
+  - jobs.yaml
+  - service-account.yaml
+
+  # included templates must also be listed
+  - configmaps_overrides.yaml
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2-urls.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2apikeys.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+tests:
+  - it: Jobs with overrides mounted
+    template: jobs.yaml
+    set:
+      st2:
+        overrides: #Enabling the override mounts in register-content job.
+          _global.yaml: |
+            ---
+            rules:
+              defaults:
+                enabled: false
+        rbac: { enabled: true } # enable rbac job
+        packs: { sensors: [] } # ensure only 1 sensor
+      jobs:
+        extra_hooks: &extra_hooks_jobs
+          - name: upgrade-warning
+            hook: pre-upgrade, pre-rollback
+            hook_weight: -5
+            command: ["st2", "run", "--tail", "custom_pack.warn_about_upgrade"]
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 5
+
+      - contains: &override_volume
+          path: spec.template.spec.volumes
+          content:
+            name: st2-overrides-vol
+            configMap:
+              name: st2ha-st2-override-configs
+        documentIndex: 3 # register_content
+
+   
+      - contains: &override_mnt
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: st2-overrides-vol
+            mountPath: /opt/stackstorm/overrides/
+        documentIndex: 3 # register_content
+
+      - notContains: *override_volume
+        documentIndex: 0
+      - notContains: *override_mnt
+        documentIndex: 0
+
+      - notContains: *override_volume
+        documentIndex: 1
+      - notContains: *override_mnt
+        documentIndex: 1
+
+      - notContains: *override_volume
+        documentIndex: 2
+      - notContains: *override_mnt
+        documentIndex: 2
+  
+  - it: Deployments with overrides
+    template: deployments.yaml
+    set:
+      st2:
+        overrides: #Enabling the override mounts in register-content job.
+          _global.yaml: |
+            ---
+            rules:
+              defaults:
+                enabled: false
+        packs:
+          sensors: [] # ensure only 1 sensor
+          images: [] # no extra packs to load
+          volumes:
+            enabled: false
+          configs: {} # has one core.yaml config file by default (dicts get merged)
+      st2chatops:
+        enabled: true
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 14
+
+
+      - contains: *override_volume # always included
+        documentIndex: 12 # st2client
+      - contains: *override_mnt # always included
+        documentIndex: 12 # st2client
+
+     
+      - notContains: *override_volume
+        documentIndex: 1
+      - notContains: *override_mnt
+        documentIndex: 1 # st2api
+      - notContains: *override_volume # only contains if volumes.enabled
+        documentIndex: 10 # st2actionrunner
+      - notContains: *override_mnt # only contains if volumes.enabled
+        documentIndex: 10 # st2actionrunner
+      - notContains: *override_volume
+        documentIndex: 0
+      - notContains: *override_mnt
+        documentIndex: 0
+      - notContains: *override_volume
+        documentIndex: 2
+      - notContains: *override_mnt
+        documentIndex: 2
+      - notContains: *override_volume
+        documentIndex: 3
+      - notContains: *override_mnt
+        documentIndex: 3
+      - notContains: *override_volume
+        documentIndex: 4
+      - notContains: *override_mnt
+        documentIndex: 4
+      - notContains: *override_volume
+        documentIndex: 5
+      - notContains: *override_mnt
+        documentIndex: 5
+      - notContains: *override_volume
+        documentIndex: 6
+      - notContains: *override_mnt
+        documentIndex: 6
+      - notContains: *override_volume
+        documentIndex: 7
+      - notContains: *override_mnt
+        documentIndex: 7
+      - notContains: *override_volume
+        documentIndex: 8
+      - notContains: *override_mnt
+        documentIndex: 8
+      - notContains: *override_volume # never
+        documentIndex: 9 # st2sensorcontainer
+      - notContains: *override_mnt # never
+        documentIndex: 9 # st2sensorcontainer
+      - notContains: *override_volume
+        documentIndex: 11
+      - notContains: *override_mnt
+        documentIndex: 11
+      - notContains: *override_volume
+        documentIndex: 13
+      - notContains: *override_mnt
+        documentIndex: 13

--- a/tests/unit/overrides_test.yaml
+++ b/tests/unit/overrides_test.yaml
@@ -57,7 +57,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: st2-overrides-vol
-            mountPath: /opt/stackstorm/overrides/
+            mountPath: /opt/stackstorm/overrides
         documentIndex: 3 # register_content
       
       - contains: *overrides_mnt

--- a/tests/unit/overrides_test.yaml
+++ b/tests/unit/overrides_test.yaml
@@ -1,5 +1,5 @@
 ---
-suite: Override check
+suite: Overrides check
 templates:
   # primary template files
   - deployments.yaml
@@ -24,7 +24,7 @@ tests:
     template: jobs.yaml
     set:
       st2:
-        overrides: #Enabling the override mounts in register-content job.
+        overrides: #Enabling the overrides mounts in register-content job.
           _global.yaml: |
             ---
             rules:
@@ -114,9 +114,9 @@ tests:
         documentIndex: 1
       - notContains: *overrides_mnt
         documentIndex: 1 # st2api
-      - notContains: *overrides_volume # only contains if volumes.enabled
+      - notContains: *overrides_volume
         documentIndex: 10 # st2actionrunner
-      - notContains: *overrides_mnt # only contains if volumes.enabled
+      - notContains: *overrides_mnt
         documentIndex: 10 # st2actionrunner
       - notContains: *overrides_volume
         documentIndex: 0

--- a/tests/unit/overrides_test.yaml
+++ b/tests/unit/overrides_test.yaml
@@ -57,23 +57,27 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: st2-overrides-vol
-            mountPath: /opt/stackstorm/overrides
+            mountPath: /opt/stackstorm/overrides/
         documentIndex: 3 # register_content
+      
+      - contains: *overrides_mnt
+        documentIndex: 4 #Extra_jobs
+      - contains: *overrides_volume
+        documentIndex: 4 #extra_jobs
 
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 0
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 0
-
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 1
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 1
+      - notContains: *overrides_volume
+        documentIndex: 2
+      - notContains: *overrides_mnt
+        documentIndex: 2
 
-      - notContains: *override_volume
-        documentIndex: 2
-      - notContains: *override_mnt
-        documentIndex: 2
   
   - it: Deployments with overrides
     template: deployments.yaml
@@ -100,61 +104,61 @@ tests:
           count: 14
 
 
-      - contains: *override_volume # always included
+      - contains: *overrides_volume # always included
         documentIndex: 12 # st2client
-      - contains: *override_mnt # always included
+      - contains: *overrides_mnt # always included
         documentIndex: 12 # st2client
 
      
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 1
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 1 # st2api
-      - notContains: *override_volume # only contains if volumes.enabled
+      - notContains: *overrides_volume # only contains if volumes.enabled
         documentIndex: 10 # st2actionrunner
-      - notContains: *override_mnt # only contains if volumes.enabled
+      - notContains: *overrides_mnt # only contains if volumes.enabled
         documentIndex: 10 # st2actionrunner
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 0
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 0
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 2
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 2
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 3
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 3
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 4
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 4
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 5
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 5
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 6
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 6
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 7
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 7
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 8
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 8
-      - notContains: *override_volume # never
+      - notContains: *overrides_volume # never
         documentIndex: 9 # st2sensorcontainer
-      - notContains: *override_mnt # never
+      - notContains: *overrides_mnt # never
         documentIndex: 9 # st2sensorcontainer
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 11
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 11
-      - notContains: *override_volume
+      - notContains: *overrides_volume
         documentIndex: 13
-      - notContains: *override_mnt
+      - notContains: *overrides_mnt
         documentIndex: 13

--- a/tests/unit/overrides_test.yaml
+++ b/tests/unit/overrides_test.yaml
@@ -44,20 +44,20 @@ tests:
       - hasDocuments:
           count: 5
 
-      - contains: &override_volume
+      - contains: &overrides_volume
           path: spec.template.spec.volumes
           content:
             name: st2-overrides-vol
             configMap:
-              name: st2ha-st2-override-configs
+              name: st2ha-st2-overrides-configs
         documentIndex: 3 # register_content
 
    
-      - contains: &override_mnt
+      - contains: &overrides_mnt
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: st2-overrides-vol
-            mountPath: /opt/stackstorm/overrides/
+            mountPath: /opt/stackstorm/overrides
         documentIndex: 3 # register_content
 
       - notContains: *override_volume

--- a/tests/unit/packs_volumes_test.yaml
+++ b/tests/unit/packs_volumes_test.yaml
@@ -6,6 +6,7 @@ templates:
   - jobs.yaml
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/placement_test.yaml
+++ b/tests/unit/placement_test.yaml
@@ -6,6 +6,7 @@ templates:
   - jobs.yaml
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/post_start_script_test.yaml
+++ b/tests/unit/post_start_script_test.yaml
@@ -6,6 +6,7 @@ templates:
   - configmaps_post-start-script.yaml
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/resources_test.yaml
+++ b/tests/unit/resources_test.yaml
@@ -7,6 +7,7 @@ templates:
   # No jobs resources yet
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/security_context_test.yaml
+++ b/tests/unit/security_context_test.yaml
@@ -6,6 +6,7 @@ templates:
   - jobs.yaml
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/service_account_test.yaml
+++ b/tests/unit/service_account_test.yaml
@@ -8,6 +8,7 @@ templates:
   # ServiceAccount doesn't attach to Jobs
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/tests/unit/st2sensors_test.yaml
+++ b/tests/unit/st2sensors_test.yaml
@@ -5,6 +5,7 @@ templates:
   - deployments.yaml
 
   # included templates must also be listed
+  - configmaps_overrides.yaml
   - configmaps_packs.yaml
   - configmaps_rbac.yaml
   - configmaps_st2-conf.yaml

--- a/values.yaml
+++ b/values.yaml
@@ -76,10 +76,10 @@ st2:
   #      defaults:
   #        enabled: true
   #  packA.yaml: |
-  #  ---
-  #  rules:
-  #    rule.name:
-  #      enabled: false
+  #    ---
+  #    rules:
+  #      rule.name:
+  #        enabled: false
   # https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
   overrides: {}
   # This mirrors the [system_user] section of st2.conf, but makes the values available for helm templating.

--- a/values.yaml
+++ b/values.yaml
@@ -77,15 +77,14 @@ st2:
     
   # Override definition settings. Eache record creates a file in `/opt/stackstorm/overrides`
   # https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
+  #configs:
+  #  _global.yaml: |
+  #  ---
+  #  rules:
+  #    defaults:
+  #      enabled: false # This will disable all rules globally.
   override:
-    enabled: false
-    # Note: This needs to be set to enabled for the directory to be made. 
-    #configs:
-    #  _global.yaml: |
-    #  ---
-    #  rules:
-    #    defaults:
-    #      enabled: false
+    enabled: true
 
   # Custom pack configs and image settings.
   #

--- a/values.yaml
+++ b/values.yaml
@@ -70,8 +70,6 @@ st2:
   
   #Override Definitions can be added here. 
   #  overrides:
-  #  enabled: true
-  #  configs:
   #    _global.yaml: |
   #    ---
   #    rules:
@@ -83,8 +81,7 @@ st2:
   #    rule.name:
   #      enabled: false
   # https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
-  overrides:
-    enabled: false
+  overrides: {}
   # This mirrors the [system_user] section of st2.conf, but makes the values available for helm templating.
   # If you change the user, you must provide a customized st2actionrunner image that includes your user.
   system_user:
@@ -1091,4 +1088,3 @@ external-dns:
   aws:
     zoneType: "public"
   domainFilters: []
-  

--- a/values.yaml
+++ b/values.yaml
@@ -82,6 +82,8 @@ st2:
   # for details on how to build this image.
   # To change this default, and use persistent/shared/writable storage that is available in your cluster, you need to
   # enable st2.packs.volumes below, adding volume definitions customized for use your cluster's storage provider.
+  override:
+    enabled: true
   packs:
     # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
     # https://docs.stackstorm.com/reference/pack_configs.html#configuration-file

--- a/values.yaml
+++ b/values.yaml
@@ -71,6 +71,7 @@ st2:
   #Override Definitions can be added here. 
   # https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
   override:
+    enabled: false
   # This mirrors the [system_user] section of st2.conf, but makes the values available for helm templating.
   # If you change the user, you must provide a customized st2actionrunner image that includes your user.
   system_user:

--- a/values.yaml
+++ b/values.yaml
@@ -69,8 +69,21 @@ st2:
     allow_origin = '*'
   
   #Override Definitions can be added here. 
+  #  overrides:
+  #  enabled: true
+  #  configs:
+  #    _global.yaml: |
+  #    ---
+  #    rules:
+  #      defaults:
+  #        enabled: true
+  #  packA.yaml: |
+  #  ---
+  #  rules:
+  #    rule.name:
+  #      enabled: false
   # https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
-  override:
+  overrides:
     enabled: false
   # This mirrors the [system_user] section of st2.conf, but makes the values available for helm templating.
   # If you change the user, you must provide a customized st2actionrunner image that includes your user.
@@ -1078,3 +1091,4 @@ external-dns:
   aws:
     zoneType: "public"
   domainFilters: []
+  

--- a/values.yaml
+++ b/values.yaml
@@ -67,24 +67,16 @@ st2:
   config: |
     [api]
     allow_origin = '*'
-
+  
+  #Override Definitions can be added here. 
+  # https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
+  override:
   # This mirrors the [system_user] section of st2.conf, but makes the values available for helm templating.
   # If you change the user, you must provide a customized st2actionrunner image that includes your user.
   system_user:
     user: stanley
     # templating is allowed for this key
     ssh_key_file: "/home/{{ .Values.st2.system_user.user }}/.ssh/stanley_rsa"
-    
-  # Override definition settings. Eache record creates a file in `/opt/stackstorm/overrides`
-  # https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
-  #configs:
-  #  _global.yaml: |
-  #  ---
-  #  rules:
-  #    defaults:
-  #      enabled: false # This will disable all rules globally.
-  override:
-    enabled: true
 
   # Custom pack configs and image settings.
   #
@@ -101,7 +93,7 @@ st2:
       core.yaml: |
         ---
         # example core pack config yaml
-    #
+
     # Custom packs images settings.
     #
     # For each given st2packs container you can define repository, name, tag and pullPolicy for this image below.
@@ -124,6 +116,8 @@ st2:
     # To use this, set enabled to true, and add cluster-specific volume definitions for at least packs and virtualenvs below.
     # Please consult the documentation for your cluster's storage solution.
     # Some generic examples are listed under st2.packs.volumes.packs below.
+    volumes:
+      enabled: false
 
       packs: {}
         # mounted to /opt/stackstorm/packs

--- a/values.yaml
+++ b/values.yaml
@@ -68,20 +68,22 @@ st2:
     [api]
     allow_origin = '*'
   
-  #Override Definitions can be added here. 
+  #Override Definitions can be added here.
+  #https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
+  overrides: {}
   #  overrides:
   #    _global.yaml: |
-  #    ---
-  #    rules:
-  #      defaults:
-  #        enabled: true
-  #  packA.yaml: |
-  #    ---
-  #    rules:
-  #      rule.name:
-  #        enabled: false
-  # https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
-  overrides: {}
+  #      ---
+  #      rules:
+  #        defaults:
+  #          enabled: true
+  #    packA.yaml: |
+  #      ---
+  #      rules:
+  #        rule.name:
+  #          enabled: false
+
+
   # This mirrors the [system_user] section of st2.conf, but makes the values available for helm templating.
   # If you change the user, you must provide a customized st2actionrunner image that includes your user.
   system_user:

--- a/values.yaml
+++ b/values.yaml
@@ -74,6 +74,18 @@ st2:
     user: stanley
     # templating is allowed for this key
     ssh_key_file: "/home/{{ .Values.st2.system_user.user }}/.ssh/stanley_rsa"
+    
+  # Override definition settings. Eache record creates a file in `/opt/stackstorm/overrides`
+  # https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
+  override:
+    enabled: false
+    # Note: This needs to be set to enabled for the directory to be made. 
+    #configs:
+    #  _global.yaml: |
+    #  ---
+    #  rules:
+    #    defaults:
+    #      enabled: false
 
   # Custom pack configs and image settings.
   #
@@ -82,8 +94,6 @@ st2:
   # for details on how to build this image.
   # To change this default, and use persistent/shared/writable storage that is available in your cluster, you need to
   # enable st2.packs.volumes below, adding volume definitions customized for use your cluster's storage provider.
-  override:
-    enabled: true
   packs:
     # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
     # https://docs.stackstorm.com/reference/pack_configs.html#configuration-file
@@ -92,7 +102,7 @@ st2:
       core.yaml: |
         ---
         # example core pack config yaml
-
+    #
     # Custom packs images settings.
     #
     # For each given st2packs container you can define repository, name, tag and pullPolicy for this image below.
@@ -115,8 +125,6 @@ st2:
     # To use this, set enabled to true, and add cluster-specific volume definitions for at least packs and virtualenvs below.
     # Please consult the documentation for your cluster's storage solution.
     # Some generic examples are listed under st2.packs.volumes.packs below.
-    volumes:
-      enabled: false
 
       packs: {}
         # mounted to /opt/stackstorm/packs


### PR DESCRIPTION
After working to get this implemented and tested. It appears that the changes I have added are working. 

This creates the `/opt/stackstorm/overrides/` mountpoint in the `st2client` pod so that if reloads happen in the pod it will keep the settings provided by users in the overrides. This also registers overrides when the st2 cluster is being built via the `register-content` job.

THis is just extending the now existing override functionality that exists in Stackstorm 3.7.0 into the HA version of Stackstorm that is now operating on version 3.7.0

```curtis-wilson:test-st2 curtis.wilson$ k -n stackstorm-local logs stackstorm-local-job-st2-register-content--1-xzwx5 -f
2022-05-13 22:08:52,283 INFO [-] Connecting to database "st2" @ "mongodb-local-headless:27017" as user "st2-admin".
2022-05-13 22:08:52,294 INFO [-] Successfully connected to database "st2" @ "mongodb-local-headless:27017" as user "st2-admin".
2022-05-13 22:08:52,734 INFO [-] =========================================================
2022-05-13 22:08:52,734 INFO [-] ############## Registering triggers #####################
2022-05-13 22:08:52,734 INFO [-] =========================================================
2022-05-13 22:08:53,152 INFO [-] Registered 1 triggers.
2022-05-13 22:08:53,152 INFO [-] =========================================================
2022-05-13 22:08:53,152 INFO [-] ############## Registering sensors ######################
2022-05-13 22:08:53,153 INFO [-] =========================================================
2022-05-13 22:08:54,528 INFO [-] Registered 40 sensors.
2022-05-13 22:08:54,529 INFO [-] 0 sensors had their metadata overridden.
2022-05-13 22:08:54,529 INFO [-] =========================================================
2022-05-13 22:08:54,529 INFO [-] ############## Registering runners ######################
2022-05-13 22:08:54,529 INFO [-] =========================================================
2022-05-13 22:08:55,912 INFO [-] Registered 14 runners.
2022-05-13 22:08:55,912 INFO [-] =========================================================
2022-05-13 22:08:55,912 INFO [-] ############## Registering actions ######################
2022-05-13 22:08:55,913 INFO [-] =========================================================
2022-05-13 22:10:24,631 INFO [-] Registered 4473 actions.
2022-05-13 22:10:24,631 INFO [-] 0 actions had their metadata overridden.
2022-05-13 22:10:24,631 INFO [-] =========================================================
2022-05-13 22:10:24,631 INFO [-] ############## Registering rules ########################
2022-05-13 22:10:24,631 INFO [-] =========================================================
2022-05-13 22:10:24,805 INFO [-] Registered 5 rules.
2022-05-13 22:10:24,805 INFO [-] 5 rules had their metadata overridden.
2022-05-13 22:10:24,805 INFO [-] =========================================================
2022-05-13 22:10:24,805 INFO [-] ############## Registering aliases ######################
2022-05-13 22:10:24,805 INFO [-] =========================================================
2022-05-13 22:10:25,081 INFO [-] Registered 15 aliases.
2022-05-13 22:10:25,081 INFO [-] 0 aliases had their metadata overridden.
2022-05-13 22:10:25,082 INFO [-] =========================================================
2022-05-13 22:10:25,082 INFO [-] ############## Registering policy types #################
2022-05-13 22:10:25,082 INFO [-] =========================================================
2022-05-13 22:10:25,112 INFO [-] Registered 3 policy types.
2022-05-13 22:10:25,112 INFO [-] =========================================================
2022-05-13 22:10:25,112 INFO [-] ############## Registering policies #####################
2022-05-13 22:10:25,112 INFO [-] =========================================================
2022-05-13 22:10:25,117 INFO [-] Registered 0 policies.
2022-05-13 22:10:25,117 INFO [-] =========================================================
2022-05-13 22:10:25,117 INFO [-] ############## Registering configs ######################
2022-05-13 22:10:25,118 INFO [-] =========================================================
2022-05-13 22:10:25,158 INFO [-] Registered 4 configs.```