### PR TITLE
Workaround to use prior bitnami repository index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312) (by @0xhaven)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -30,17 +30,17 @@ details:
 dependencies:
   - name: rabbitmq
     version: 8.0.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami
     condition: rabbitmq.enabled
   - name: mongodb
     version: 10.0.1
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami
     condition: mongodb.enabled
   - name: external-dns
     version: 4.0.0
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami
     condition: external-dns.enabled
   - name: redis
     version: 12.3.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami
     condition: redis.enabled


### PR DESCRIPTION
Workaround to use previous index from: https://github.com/bitnami/charts/issues/10539

Temporary workaround for #311 