### PR TITLE
Add Ability to Write/Use st2.secrets.conf from K8s Secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In Development
 * Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312 #318) (by @0xhaven)
 * Refactor label definitions to be more consistent by building labels and label selectors in partial helper templates. (#299) (by @cognifloyd)
+* New Feature: Add `existingConfigSecret` .  If this is defined, the `st2.secrets.conf` key within this secret will be written as /etc/st2/st2.secrets.conf and added to the end of the command line arguments of all pods. (#289) (by @eric-al)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -124,11 +124,31 @@ Reduce duplication of the st2.*.conf volume details
 - name: st2-config-vol
   mountPath: /etc/st2/st2.user.conf
   subPath: st2.user.conf
+{{- if $.Values.st2.existingConfigSecret }}
+- name: st2-config-secrets-vol
+  mountPath: /etc/st2/st2.secrets.conf
+  subPath: st2.secrets.conf
+{{- end }}
 {{- end -}}
 {{- define "stackstorm-ha.st2-config-volume" -}}
 - name: st2-config-vol
   configMap:
     name: {{ $.Release.Name }}-st2-config
+{{- if $.Values.st2.existingConfigSecret }}
+- name: st2-config-secrets-vol
+  secret:
+    secretName: {{ $.Values.st2.existingConfigSecret }}
+{{- end }}
+{{- end -}}
+
+# Override CMD CLI parameters passed to the startup of all pods to add support for /etc/st2/st2.secrets.conf
+{{- define "stackstorm-ha.st2-config-file-parameters" -}}
+- --config-file=/etc/st2/st2.conf
+- --config-file=/etc/st2/st2.docker.conf
+- --config-file=/etc/st2/st2.user.conf
+{{- if $.Values.st2.existingConfigSecret }}
+- --config-file=/etc/st2/st2.secrets.conf
+{{- end }}
 {{- end -}}
 
 {{- define "stackstorm-ha.init-containers-wait-for-db" -}}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -7,7 +7,6 @@ metadata:
     description: Custom StackStorm config which will apply settings on top of default st2.conf
   labels: {{- include "stackstorm-ha.labels" (list $ "st2") | nindent 4 }}
 data:
-  # TODO: Bundle DB/MQ login secrets in dynamic ENV-based st2.secrets.conf, leave custom user-defined settings for st2.user.conf (?)
   # Docker/K8s-based st2 config file used for templating service names and common overrides on top of original st2.conf.
   # The order of merging: st2.conf < st2.docker.conf < st2.user.conf
   st2.docker.conf: |

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -72,6 +72,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2auth
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2auth.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2auth | nindent 8 }}
         {{- end }}
@@ -188,6 +191,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2api
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2api.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2api | nindent 8 }}
         {{- end }}
@@ -311,6 +317,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2stream
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2stream.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2stream | nindent 8 }}
         {{- end }}
@@ -540,6 +549,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2rulesengine
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2rulesengine.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2rulesengine | nindent 8 }}
         {{- end }}
@@ -654,6 +666,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2timersengine
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2timersengine.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2timersengine | nindent 8 }}
         {{- end }}
@@ -755,6 +770,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2workflowengine
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2workflowengine.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2workflowengine | nindent 8 }}
         {{- end }}
@@ -868,6 +886,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2scheduler
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2scheduler.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2scheduler | nindent 8 }}
         {{- end }}
@@ -981,6 +1002,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2notifier
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2notifier.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2notifier | nindent 8 }}
         {{- end }}
@@ -1150,12 +1174,9 @@ spec:
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if or $one_sensor_per_pod $some_sensors_per_pod }}{{/* ie: when there is more than one pod of sensors */}}
         command:
           - /opt/stackstorm/st2/bin/st2sensorcontainer
-          - --config-file=/etc/st2/st2.conf
-          - --config-file=/etc/st2/st2.docker.conf
-          - --config-file=/etc/st2/st2.user.conf
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
           {{- if $one_sensor_per_pod }}{{/* only in st2.packs.sensors[] */}}
           - --single-sensor-mode
           - --sensor-ref={{ required "You must define `ref` for everything in st2.packs.sensors. This assigns each sensor to a pod." $sensor.ref }}
@@ -1163,7 +1184,6 @@ spec:
           # injected by {{ $name }}-init-config
           - --config-file=/etc/st2/st2.sensorcontainer.conf
           {{- end }}
-        {{- end }}
         {{- if $sensor.env }}
         env: {{- include "stackstorm-ha.customEnv" $sensor | nindent 8 }}
         {{- end }}
@@ -1308,6 +1328,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2actionrunner
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2actionrunner.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2actionrunner | nindent 8 }}
         {{- end }}
@@ -1439,6 +1462,9 @@ spec:
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
+        command:
+          - /opt/stackstorm/st2/bin/st2garbagecollector
+          {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2garbagecollector.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.st2garbagecollector | nindent 8 }}
         {{- end }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -39,9 +39,7 @@ spec:
         command:
           - st2-apply-rbac-definitions
           - --verbose
-          - --config-file=/etc/st2/st2.conf
-          - --config-file=/etc/st2/st2.docker.conf
-          - --config-file=/etc/st2/st2.user.conf
+          {{- include "stackstorm-ha.st2-config-file-parameters" . | nindent 10 }}
         {{- if .Values.jobs.env }}
         env: {{- include "stackstorm-ha.customEnv" .Values.jobs | nindent 8 }}
         {{- end }}
@@ -413,9 +411,7 @@ spec:
         {{- end }}
         command:
           - st2-register-content
-          - --config-file=/etc/st2/st2.conf
-          - --config-file=/etc/st2/st2.docker.conf
-          - --config-file=/etc/st2/st2.user.conf
+          {{- include "stackstorm-ha.st2-config-file-parameters" . | nindent 10 }}
           - --register-all
           - --register-fail-on-failure
         {{- if .Values.jobs.env }}

--- a/tests/unit/st2_conf_files_test.yaml
+++ b/tests/unit/st2_conf_files_test.yaml
@@ -1,0 +1,664 @@
+---
+suite: Config files
+templates:
+  # primary template files
+  - deployments.yaml
+  - jobs.yaml
+
+  # included templates must also be listed
+  - configmaps_overrides.yaml
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2-urls.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2apikeys.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+tests:
+  - it: Jobs include st2.conf files by default
+    template: jobs.yaml
+    set:
+      st2:
+        rbac: { enabled: true } # enable rbac job
+      jobs:
+        # The extra_hooks job will NOT need the command arguments, but it does need the volumes.
+        extra_hooks: &extra_hooks_jobs
+          - name: upgrade-warning
+            hook: pre-upgrade, pre-rollback
+            hook_weight: -5
+            command: ["st2", "run", "--tail", "custom_pack.warn_about_upgrade"]
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 5
+
+      - contains: &st2conf_cli
+          path: spec.template.spec.containers[0].command
+          content: '--config-file=/etc/st2/st2.conf'
+        documentIndex: 0 # apply-rbac-definitions job
+      - contains: *st2conf_cli
+        documentIndex: 3 # register-content
+
+      - contains: &st2dockerconf_cli
+          path: spec.template.spec.containers[0].command
+          content: '--config-file=/etc/st2/st2.docker.conf'
+        documentIndex: 0
+      - contains: *st2dockerconf_cli
+        documentIndex: 3
+
+      - contains: &st2userconf_cli
+          path: spec.template.spec.containers[0].command
+          content: '--config-file=/etc/st2/st2.user.conf'
+        documentIndex: 0
+      - contains: *st2userconf_cli
+        documentIndex: 3
+
+      - notContains: &st2secretsconf_cli
+          path: spec.template.spec.containers[0].command
+          content: '--config-file=/etc/st2/st2.secrets.conf'
+        documentIndex: 0
+      - notContains: *st2secretsconf_cli
+        documentIndex: 3
+
+      - contains: &st2conf_vol
+          path: spec.template.spec.volumes
+          content:
+            name: st2-config-vol
+            configMap:
+              name: st2ha-st2-config
+        documentIndex: 0 # apply-rbac-definitions job
+      # TODO: st2-key-load currently has the volume+mounts, but does it need it?
+      #- contains: *st2conf_vol
+      #  documentIndex: 2 # st2-key-load
+      - contains: *st2conf_vol
+        documentIndex: 3 # register-content
+      - contains: *st2conf_vol
+        documentIndex: 4 # extra_hooks
+
+      # st2.docker.conf included in st2conf_vol
+      - contains: &st2conf_vol_docker_mnt
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: st2-config-vol
+            mountPath: /etc/st2/st2.docker.conf
+            subPath: st2.docker.conf
+        documentIndex: 0
+      #- contains: *st2conf_vol_docker_mnt
+      #  documentIndex: 2
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 3
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 4
+
+      # st2.user.conf included in st2conf_vol
+      - contains: &st2conf_vol_user_mnt
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: st2-config-vol
+            mountPath: /etc/st2/st2.user.conf
+            subPath: st2.user.conf
+        documentIndex: 0
+      #- contains: *st2conf_vol_user_mnt
+      #  documentIndex: 2
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 3
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 4
+
+      - notContains: &st2secretsconf_vol
+          path: spec.template.spec.volumes
+          content:
+            name: st2-config-secrets-vol
+            secret:
+              secretName: stackstorm-config-secret
+        documentIndex: 0
+      #- notContains: *st2secretsconf_vol
+      #  documentIndex: 2
+      - notContains: *st2secretsconf_vol
+        documentIndex: 3
+      - notContains: *st2secretsconf_vol
+        documentIndex: 4
+
+      - notContains: &st2secretsconf_vol_mnt
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: st2-config-secrets-vol
+            mountPath: /etc/st2/st2.secrets.conf
+            subPath: st2.secrets.conf
+        documentIndex: 0
+      #- notContains: *st2secretsconf_vol_mnt
+      #  documentIndex: 2
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 3
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 4
+
+  - it: Deployments include st2.conf files by default
+    template: deployments.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: false
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 13
+
+      # all deployments except for st2web (index 3) and st2client (index 12)
+      - contains: *st2conf_cli
+        documentIndex: 0
+      - contains: *st2conf_cli
+        documentIndex: 1
+      - contains: *st2conf_cli
+        documentIndex: 2
+      - contains: *st2conf_cli
+        documentIndex: 4
+      - contains: *st2conf_cli
+        documentIndex: 5
+      - contains: *st2conf_cli
+        documentIndex: 6
+      - contains: *st2conf_cli
+        documentIndex: 7
+      - contains: *st2conf_cli
+        documentIndex: 8
+      - contains: *st2conf_cli
+        documentIndex: 9
+      - contains: *st2conf_cli
+        documentIndex: 10
+      - contains: *st2conf_cli
+        documentIndex: 11
+
+      - contains: *st2dockerconf_cli
+        documentIndex: 0
+      - contains: *st2dockerconf_cli
+        documentIndex: 1
+      - contains: *st2dockerconf_cli
+        documentIndex: 2
+      - contains: *st2dockerconf_cli
+        documentIndex: 4
+      - contains: *st2dockerconf_cli
+        documentIndex: 5
+      - contains: *st2dockerconf_cli
+        documentIndex: 6
+      - contains: *st2dockerconf_cli
+        documentIndex: 7
+      - contains: *st2dockerconf_cli
+        documentIndex: 8
+      - contains: *st2dockerconf_cli
+        documentIndex: 9
+      - contains: *st2dockerconf_cli
+        documentIndex: 10
+      - contains: *st2dockerconf_cli
+        documentIndex: 11
+
+      - contains: *st2userconf_cli
+        documentIndex: 0
+      - contains: *st2userconf_cli
+        documentIndex: 1
+      - contains: *st2userconf_cli
+        documentIndex: 2
+      - contains: *st2userconf_cli
+        documentIndex: 4
+      - contains: *st2userconf_cli
+        documentIndex: 5
+      - contains: *st2userconf_cli
+        documentIndex: 6
+      - contains: *st2userconf_cli
+        documentIndex: 7
+      - contains: *st2userconf_cli
+        documentIndex: 8
+      - contains: *st2userconf_cli
+        documentIndex: 9
+      - contains: *st2userconf_cli
+        documentIndex: 10
+      - contains: *st2userconf_cli
+        documentIndex: 11
+
+      - notContains: *st2secretsconf_cli
+        documentIndex: 0
+      - notContains: *st2secretsconf_cli
+        documentIndex: 1
+      - notContains: *st2secretsconf_cli
+        documentIndex: 2
+      - notContains: *st2secretsconf_cli
+        documentIndex: 4
+      - notContains: *st2secretsconf_cli
+        documentIndex: 5
+      - notContains: *st2secretsconf_cli
+        documentIndex: 6
+      - notContains: *st2secretsconf_cli
+        documentIndex: 7
+      - notContains: *st2secretsconf_cli
+        documentIndex: 8
+      - notContains: *st2secretsconf_cli
+        documentIndex: 9
+      - notContains: *st2secretsconf_cli
+        documentIndex: 10
+      - notContains: *st2secretsconf_cli
+        documentIndex: 11
+
+      - contains: *st2conf_vol
+        documentIndex: 0
+      - contains: *st2conf_vol
+        documentIndex: 1
+      - contains: *st2conf_vol
+        documentIndex: 2
+      - contains: *st2conf_vol
+        documentIndex: 4
+      - contains: *st2conf_vol
+        documentIndex: 5
+      - contains: *st2conf_vol
+        documentIndex: 6
+      - contains: *st2conf_vol
+        documentIndex: 7
+      - contains: *st2conf_vol
+        documentIndex: 8
+      - contains: *st2conf_vol
+        documentIndex: 9
+      - contains: *st2conf_vol
+        documentIndex: 10
+      - contains: *st2conf_vol
+        documentIndex: 11
+
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 0
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 1
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 2
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 4
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 5
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 6
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 7
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 8
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 9
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 10
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 11
+
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 0
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 1
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 2
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 4
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 5
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 6
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 7
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 8
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 9
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 10
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 11
+
+      - notContains: *st2secretsconf_vol
+        documentIndex: 0
+      - notContains: *st2secretsconf_vol
+        documentIndex: 1
+      - notContains: *st2secretsconf_vol
+        documentIndex: 2
+      - notContains: *st2secretsconf_vol
+        documentIndex: 4
+      - notContains: *st2secretsconf_vol
+        documentIndex: 5
+      - notContains: *st2secretsconf_vol
+        documentIndex: 6
+      - notContains: *st2secretsconf_vol
+        documentIndex: 7
+      - notContains: *st2secretsconf_vol
+        documentIndex: 8
+      - notContains: *st2secretsconf_vol
+        documentIndex: 9
+      - notContains: *st2secretsconf_vol
+        documentIndex: 10
+      - notContains: *st2secretsconf_vol
+        documentIndex: 11
+
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 0
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 1
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 2
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 4
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 5
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 6
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 7
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 8
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 9
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 10
+      - notContains: *st2secretsconf_vol_mnt
+        documentIndex: 11
+
+  - it: Jobs include st2.conf files with st2.existingConfigSecret
+    template: jobs.yaml
+    set:
+      st2:
+        rbac: { enabled: true } # enable rbac job
+        existingConfigSecret: stackstorm-config-secret
+      jobs:
+        # The extra_hooks job will NOT need the command arguments, but it does need the volumes.
+        extra_hooks: *extra_hooks_jobs
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 5
+
+      - contains: *st2secretsconf_cli
+        documentIndex: 0
+      - contains: *st2secretsconf_cli
+        documentIndex: 3
+
+      # also make sure that the other conf files are still present
+      - contains: *st2conf_cli
+        documentIndex: 0
+      - contains: *st2conf_cli
+        documentIndex: 3
+
+      - contains: *st2dockerconf_cli
+        documentIndex: 0
+      - contains: *st2dockerconf_cli
+        documentIndex: 3
+
+      - contains: *st2userconf_cli
+        documentIndex: 0
+      - contains: *st2userconf_cli
+        documentIndex: 3
+
+      - contains: *st2conf_vol
+        documentIndex: 0
+      #- contains: *st2conf_vol
+      #  documentIndex: 2
+      - contains: *st2conf_vol
+        documentIndex: 3
+      - contains: *st2conf_vol
+        documentIndex: 4
+
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 0
+      #- contains: *st2conf_vol_docker_mnt
+      #  documentIndex: 2
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 3
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 4
+
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 0
+      #- contains: *st2conf_vol_user_mnt
+      #  documentIndex: 2
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 3
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 4
+
+      - contains: *st2secretsconf_vol
+        documentIndex: 0
+      #- contains: *st2secretsconf_vol
+      #  documentIndex: 2
+      - contains: *st2secretsconf_vol
+        documentIndex: 3
+      - contains: *st2secretsconf_vol
+        documentIndex: 4
+
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 0
+      #- contains: *st2secretsconf_vol_mnt
+      #  documentIndex: 2
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 3
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 4
+
+  - it: Deployments include st2.conf files with st2.existingConfigSecret
+    template: deployments.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+        existingConfigSecret: stackstorm-config-secret
+      st2chatops:
+        enabled: false
+    release:
+      name: st2ha
+    asserts:
+      - hasDocuments:
+          count: 13
+
+      # all deployments except for st2web (index 3) and st2client (index 12)
+      - contains: *st2secretsconf_cli
+        documentIndex: 0
+      - contains: *st2secretsconf_cli
+        documentIndex: 1
+      - contains: *st2secretsconf_cli
+        documentIndex: 2
+      - contains: *st2secretsconf_cli
+        documentIndex: 4
+      - contains: *st2secretsconf_cli
+        documentIndex: 5
+      - contains: *st2secretsconf_cli
+        documentIndex: 6
+      - contains: *st2secretsconf_cli
+        documentIndex: 7
+      - contains: *st2secretsconf_cli
+        documentIndex: 8
+      - contains: *st2secretsconf_cli
+        documentIndex: 9
+      - contains: *st2secretsconf_cli
+        documentIndex: 10
+      - contains: *st2secretsconf_cli
+        documentIndex: 11
+
+      - contains: *st2secretsconf_vol
+        documentIndex: 0
+      - contains: *st2secretsconf_vol
+        documentIndex: 1
+      - contains: *st2secretsconf_vol
+        documentIndex: 2
+      - contains: *st2secretsconf_vol
+        documentIndex: 4
+      - contains: *st2secretsconf_vol
+        documentIndex: 5
+      - contains: *st2secretsconf_vol
+        documentIndex: 6
+      - contains: *st2secretsconf_vol
+        documentIndex: 7
+      - contains: *st2secretsconf_vol
+        documentIndex: 8
+      - contains: *st2secretsconf_vol
+        documentIndex: 9
+      - contains: *st2secretsconf_vol
+        documentIndex: 10
+      - contains: *st2secretsconf_vol
+        documentIndex: 11
+
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 0
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 1
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 2
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 4
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 5
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 6
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 7
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 8
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 9
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 10
+      - contains: *st2secretsconf_vol_mnt
+        documentIndex: 11
+
+      # also make sure that the other conf files are still present
+      - contains: *st2conf_cli
+        documentIndex: 0
+      - contains: *st2conf_cli
+        documentIndex: 1
+      - contains: *st2conf_cli
+        documentIndex: 2
+      - contains: *st2conf_cli
+        documentIndex: 4
+      - contains: *st2conf_cli
+        documentIndex: 5
+      - contains: *st2conf_cli
+        documentIndex: 6
+      - contains: *st2conf_cli
+        documentIndex: 7
+      - contains: *st2conf_cli
+        documentIndex: 8
+      - contains: *st2conf_cli
+        documentIndex: 9
+      - contains: *st2conf_cli
+        documentIndex: 10
+      - contains: *st2conf_cli
+        documentIndex: 11
+
+      - contains: *st2dockerconf_cli
+        documentIndex: 0
+      - contains: *st2dockerconf_cli
+        documentIndex: 1
+      - contains: *st2dockerconf_cli
+        documentIndex: 2
+      - contains: *st2dockerconf_cli
+        documentIndex: 4
+      - contains: *st2dockerconf_cli
+        documentIndex: 5
+      - contains: *st2dockerconf_cli
+        documentIndex: 6
+      - contains: *st2dockerconf_cli
+        documentIndex: 7
+      - contains: *st2dockerconf_cli
+        documentIndex: 8
+      - contains: *st2dockerconf_cli
+        documentIndex: 9
+      - contains: *st2dockerconf_cli
+        documentIndex: 10
+      - contains: *st2dockerconf_cli
+        documentIndex: 11
+
+      - contains: *st2userconf_cli
+        documentIndex: 0
+      - contains: *st2userconf_cli
+        documentIndex: 1
+      - contains: *st2userconf_cli
+        documentIndex: 2
+      - contains: *st2userconf_cli
+        documentIndex: 4
+      - contains: *st2userconf_cli
+        documentIndex: 5
+      - contains: *st2userconf_cli
+        documentIndex: 6
+      - contains: *st2userconf_cli
+        documentIndex: 7
+      - contains: *st2userconf_cli
+        documentIndex: 8
+      - contains: *st2userconf_cli
+        documentIndex: 9
+      - contains: *st2userconf_cli
+        documentIndex: 10
+      - contains: *st2userconf_cli
+        documentIndex: 11
+
+      - contains: *st2conf_vol
+        documentIndex: 0
+      - contains: *st2conf_vol
+        documentIndex: 1
+      - contains: *st2conf_vol
+        documentIndex: 2
+      - contains: *st2conf_vol
+        documentIndex: 4
+      - contains: *st2conf_vol
+        documentIndex: 5
+      - contains: *st2conf_vol
+        documentIndex: 6
+      - contains: *st2conf_vol
+        documentIndex: 7
+      - contains: *st2conf_vol
+        documentIndex: 8
+      - contains: *st2conf_vol
+        documentIndex: 9
+      - contains: *st2conf_vol
+        documentIndex: 10
+      - contains: *st2conf_vol
+        documentIndex: 11
+
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 0
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 1
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 2
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 4
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 5
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 6
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 7
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 8
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 9
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 10
+      - contains: *st2conf_vol_docker_mnt
+        documentIndex: 11
+
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 0
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 1
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 2
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 4
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 5
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 6
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 7
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 8
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 9
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 10
+      - contains: *st2conf_vol_user_mnt
+        documentIndex: 11

--- a/tests/unit/st2sensors_test.yaml
+++ b/tests/unit/st2sensors_test.yaml
@@ -62,11 +62,14 @@ tests:
           value: all-sensors-in-one-pod
         documentIndex: *first_sensor_doc
 
-      - isNull:
+      - notContains: &singleSensorMode
           path: spec.template.spec.containers[0].command
-      #- notContains:
-      #    path: spec.template.spec.containers[0].command
-      #    content: '--single-sensor-mode'
+          content: '--single-sensor-mode'
+        documentIndex: *first_sensor_doc
+
+      - notContains: &sensorConf
+          path: spec.template.spec.containers[0].command
+          content: '--config-file=/etc/st2/st2.sensorcontainer.conf'
         documentIndex: *first_sensor_doc
 
   - it: stackstorm/sensor-mode = one-sensor-per-pod
@@ -183,9 +186,7 @@ tests:
       - equal: *oneSensorAnnotation
         documentIndex: *third_sensor_doc
 
-      - contains: &singleSensorMode
-          path: spec.template.spec.containers[0].command
-          content: '--single-sensor-mode'
+      - contains: *singleSensorMode
         documentIndex: *first_sensor_doc
       - contains: *singleSensorMode
         documentIndex: *second_sensor_doc
@@ -346,18 +347,14 @@ tests:
       - equal: *multiSensorAnnotation
         documentIndex: *third_sensor_doc
 
-      - notContains: &notSingleSensorMode
-          path: spec.template.spec.containers[0].command
-          content: '--single-sensor-mode'
+      - notContains: *singleSensorMode
         documentIndex: *first_sensor_doc
-      - notContains: *notSingleSensorMode
+      - notContains: *singleSensorMode
         documentIndex: *second_sensor_doc
-      - notContains: *notSingleSensorMode
+      - notContains: *singleSensorMode
         documentIndex: *third_sensor_doc
 
-      - contains: &sensorConf
-          path: spec.template.spec.containers[0].command
-          content: '--config-file=/etc/st2/st2.sensorcontainer.conf'
+      - contains: *sensorConf
         documentIndex: *first_sensor_doc
       - contains: *sensorConf
         documentIndex: *second_sensor_doc

--- a/values.yaml
+++ b/values.yaml
@@ -84,6 +84,12 @@ st2:
   #          enabled: false
 
 
+  # Custom StackStorm config (st2.secret.conf) which will be created from the key 'st2.secret.conf' within this secret.
+  # If this is defined, '--config-file=/etc/st2/st2.secrets.conf' will be added to the end of the command line arguments 
+  # for all pods, superseding all other configuration values.
+  # This secret must be populated outside of this chart.
+  # existingConfigSecret: stackstorm-config-secret
+
   # This mirrors the [system_user] section of st2.conf, but makes the values available for helm templating.
   # If you change the user, you must provide a customized st2actionrunner image that includes your user.
   system_user:
@@ -971,7 +977,7 @@ mongodb:
     rootPassword: "8fAzdnksdzPFUWm4a68EfY7nMhBPaa"
     # Initial database for stackstorm
     database: "st2"
-    # Minimal key length is 6 symbols
+    # Minimal key length is 6 symbols and may only contain characters in the base64 set.
     replicaSetKey: "82PItDpqroti5RngOA7UqbHH7c6bFUwy"
     # Whether to enable the arbiter
   arbiter:

--- a/values.yaml
+++ b/values.yaml
@@ -84,7 +84,7 @@ st2:
   #          enabled: false
 
 
-  # Custom StackStorm config (st2.secret.conf) which will be created from the key 'st2.secret.conf' within this secret.
+  # Custom StackStorm config (st2.secrets.conf) which will be created from the key 'st2.secrets.conf' within this secret.
   # If this is defined, '--config-file=/etc/st2/st2.secrets.conf' will be added to the end of the command line arguments 
   # for all pods, superseding all other configuration values.
   # This secret must be populated outside of this chart.


### PR DESCRIPTION
This PR adds the capability to define '/etc/st2/st2.secret.conf' in a Kubernetes secret.  No longer will users need things like helm-secrets to safely store secret values that ultimately wind up in /etc/st2/*.conf.

If this is defined, the contents of key 'st2.secret.conf' within the defined secret name will be written to '/etc/st2/st2.secret.conf' on all pods.  In addition, '--config-file=/etc/st2/st2.secrets.conf' will be added to the end of the command line arguments for all pods, superseding all other configuration values.

This addresses the Comment-Based-TODO here:  https://github.com/alertlogic/stackstorm-ha/blob/master/templates/configmaps_st2-conf.yaml#L16

This replaces #289 as @ericreeves no longer has access to the @eric-al account used to create that (based on DM with Eric in slack). Plus I added unit tests.