### PR TITLE
Fix `jobs.preRegisterContentCommand` init container mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## In Development
 * Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312 #318) (by @0xhaven)
 * Refactor label definitions to be more consistent by building labels and label selectors in partial helper templates. (#299) (by @cognifloyd)
-* Use the correct `apiVersion` for `Ingress` to add support for Kubernetes `v1.22`. (by @arms11)
+* Use the correct `apiVersion` for `Ingress` to add support for Kubernetes `v1.22`. (#301) (by @arms11)
+* Fix mounts for `jobs.preRegisterContentCommand` container to use the same mounts as the primary register-content container. (#322) (by @cognifloyd)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -394,15 +394,10 @@ spec:
         {{- end }}
         command: {{- toYaml $.Values.jobs.preRegisterContentCommand | nindent 8 }}
         volumeMounts:
+        {{- include "stackstorm-ha.overrides-config-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
-        - name: st2-pack-configs-vol
-          mountPath: /opt/stackstorm/configs/
-        {{- if .Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs/
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs/
-        {{- end }}
+        {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" . | nindent 8 }}
       {{ end }}
       containers:
       - name: st2-register-content


### PR DESCRIPTION
The initContainer for `jobs.preRegisterContentCommand` did not get some of the updates applied to the primary register-content command container. That may be the source of (part of) the issue reported in #320. Whether or not this fixes that issue, the mounts still need to be fixed / synchronized with the primary mounts.

Sadly, testing initContainers with helm-unittest is going to be extremely difficult because it requires assertions using the exact index of the container. When helm-unittest adds support for looking up an object in an array using a key, like name, then we can add tests for initContainers. Until then, we just have to do our best to keep the initContainers synchronized as needed.
