### PR TITLE
Address issue with register content when configuring volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Use the correct `apiVersion` for `Ingress` to add support for Kubernetes `v1.22`. (#301) (by @arms11)
 * Fix mounts for `jobs.preRegisterContentCommand` container to use the same mounts as the primary register-content container. (#322) (by @cognifloyd)
 * Add support for providing custom st2actionrunner-specific docker repository, image name, pull policy, and pull secret via `values.yaml`. (#141) (by @Sheshagiri)
+* Fix bug that hung an init container when `st2.packs.volumes.enabled` without `st2.packs.volumes.configs`. (#324) (by @rebrowning)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -304,7 +304,7 @@ Merge packs and virtualenvs from st2 with those from st2packs images
   securityContext: {{- toYaml . | nindent 8 }}
   {{- end }}
   {{- end }}
-  {{- if and $.Values.st2.packs.configs $.Values.st2.packs.volumes.enabled }}
+  {{- if and $.Values.st2.packs.configs $.Values.st2.packs.volumes.enabled $.Values.st2.packs.volumes.configs }}
 # Pack configs defined in helm values
 - name: st2-pack-configs-from-helm
   image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'


### PR DESCRIPTION
add the additional check to the condition, since what is happening is the container is attempting to run but the st2-pack-configs-from-helm-vol is not being created because the condition is not met

I've been digging in to try and understand what the init containers are doing, but the root of the problem is the init container is expecting a volume that doesn't exist as part of the pod as part of a condition, so I simply added the condition to the init container causing the issue.

If there's a better way to resolve it please let me know and I'll take a look.

Fixes #320