### PR TITLE
fix for the redis password not being set in the connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix mounts for `jobs.preRegisterContentCommand` container to use the same mounts as the primary register-content container. (#322) (by @cognifloyd)
 * Add support for providing custom st2actionrunner-specific docker repository, image name, pull policy, and pull secret via `values.yaml`. (#141) (by @Sheshagiri)
 * Fix bug that hung an init container when `st2.packs.volumes.enabled` without `st2.packs.volumes.configs`. (#324) (by @rebrowning)
+* Fix bug that would not set the appropriate redis connection string when using `redis.password` and `redis.usePassword` (#325) (by @rebrowning)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -114,6 +114,13 @@ Generate list of nodes for Redis with Sentinel connection string, based on numbe
 {{- end -}}
 {{- end -}}
 
+{{- define "stackstorm-ha.redis-password" -}}
+{{- if not .Values.redis.sentinel.enabled }}
+{{- fail "value for redis.sentinel.enabled MUST be true" }}
+{{- end }}
+{{- if not (empty .Values.redis.password)}}:{{ .Values.redis.password }}@{{- end }}
+{{- end -}}
+
 {{/*
 Reduce duplication of the st2.*.conf volume details
 */}}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -18,7 +18,7 @@ data:
     ssh_key_file = {{ tpl .Values.st2.system_user.ssh_key_file . }}
     {{- if index .Values "redis" "enabled" }}
     [coordination]
-    url = redis://{{ template "stackstorm-ha.redis-nodes" $ }}
+    url = redis://{{ template "stackstorm-ha.redis-password" $ }}{{ template "stackstorm-ha.redis-nodes" $ }}
     {{- end }}
     {{- if index .Values "rabbitmq" "enabled" }}
     [messaging]

--- a/values.yaml
+++ b/values.yaml
@@ -67,7 +67,7 @@ st2:
   config: |
     [api]
     allow_origin = '*'
-  
+
   #Override Definitions can be added here.
   #https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
   overrides: {}
@@ -1052,10 +1052,15 @@ redis:
   # https://github.com/bitnami/charts/tree/master/bitnami/redis#master-slave-with-sentinel
   sentinel:
     enabled: true
+    # DO NOT SET sentinel.usePassword, the tooz driver under the hood cannot connect to a password protected sentinel
+    # however it can connect to a password protected redis that is being managed by sentinel
+    # usePassword: false
     # Enable or disable static sentinel IDs for each replicas
     # If disabled each sentinel will generate a random id at startup
     # If enabled, each replicas will have a constant ID on each start-up
     staticID: true
+  # if redis.usePassword is true, you can set the password here
+  # password: mysupersecretpassword
   networkPolicy:
     enabled: false
   usePassword: false

--- a/values.yaml
+++ b/values.yaml
@@ -1052,7 +1052,7 @@ redis:
   # https://github.com/bitnami/charts/tree/master/bitnami/redis#master-slave-with-sentinel
   sentinel:
     enabled: true
-    # DO NOT SET sentinel.usePassword, the tooz driver under the hood cannot connect to a password protected sentinel
+    # DO NOT SET sentinel.usePassword, the tooz driver cannot connect to a password protected sentinel
     # however it can connect to a password protected redis that is being managed by sentinel
     # usePassword: false
     # Enable or disable static sentinel IDs for each replicas


### PR DESCRIPTION
I'd like some feedback on how we want to handle this.

There are other options with how to configure redis in the underlying bitnami chart (generated password, secretfile). However I don't know how to grab either the generated helm value or the value from the secret file to then inject it into the redis url. Are there some additional coordination parameters we can use in st2 to set the password or an environment variable that st2 will consume for the redis password?

Additionally, you can set sentinel to be protected by the same password as well, however this `DOES NOT` work due to the tooz driver not populating the password for the sentinel client, only for the redis client that gets created from the sentinel get master request.