### PR TITLE
Adding the ability to service account to accept custom labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix mounts for `jobs.preRegisterContentCommand` container to use the same mounts as the primary register-content container. (#322) (by @cognifloyd)
 * Add support for providing custom st2actionrunner-specific docker repository, image name, pull policy, and pull secret via `values.yaml`. (#141) (by @Sheshagiri)
 * Fix bug that hung an init container when `st2.packs.volumes.enabled` without `st2.packs.volumes.configs`. (#324) (by @rebrowning)
+* Add ability to create custom labels for service account.(#)(by @SuganJoe)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fix mounts for `jobs.preRegisterContentCommand` container to use the same mounts as the primary register-content container. (#322) (by @cognifloyd)
 * Add support for providing custom st2actionrunner-specific docker repository, image name, pull policy, and pull secret via `values.yaml`. (#141) (by @Sheshagiri)
 * Fix bug that hung an init container when `st2.packs.volumes.enabled` without `st2.packs.volumes.configs`. (#324) (by @rebrowning)
-* Add ability to create custom labels for service account.(#)(by @SuganJoe)
+* Add ability to create custom labels for service account.(#327)(by @SuganJoe)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- toYaml .Values.serviceAccount.serviceAccountAnnotations | nindent 4 }}
   {{- end }}
   labels: {{- include "stackstorm-ha.labels" (list $ (include "stackstorm-ha.name" $)) | nindent 4 }}
+    {{- if .Values.serviceAccount.serviceAccountLabels }}
+    {{- toYaml .Values.serviceAccount.serviceAccountLabels | nindent 4 }}
+    {{- end }}
   {{- if .Values.serviceAccount.pullSecret }}
 imagePullSecrets:
 - name: "{{ .Values.serviceAccount.pullSecret }}"

--- a/tests/unit/labels_test.yaml
+++ b/tests/unit/labels_test.yaml
@@ -219,10 +219,10 @@ tests:
     set:
       serviceAccount:
         create: true
-        serviceAccountLabels: &labels
+        serviceAccountLabels:
           foo: bar
           answer: "42"
-    asserts: &labels_asserts
+    asserts:
       - isNotNull:
           path: metadata.labels
       - equal:

--- a/tests/unit/labels_test.yaml
+++ b/tests/unit/labels_test.yaml
@@ -214,6 +214,24 @@ tests:
           path: metadata.labels.heritage
           value: Helm
 
+  - it: ServiceAccount accepts custom labels
+    template: service-account.yaml
+    set:
+      serviceAccount:
+        create: true
+        serviceAccountLabels: &labels
+          foo: bar
+          answer: "42"
+    asserts: &labels_asserts
+      - isNotNull:
+          path: metadata.labels
+      - equal:
+          path: metadata.labels.foo
+          value: bar
+      - equal:
+          path: metadata.labels.answer
+          value: "42"
+
   - it: st2web Ingress has required labels
     template: ingress.yaml
     set:

--- a/values.yaml
+++ b/values.yaml
@@ -32,6 +32,9 @@ serviceAccount:
   serviceAccountAnnotations: {}
   # Used to override service account name
   serviceAccountName:
+  # Used to define any custom labels required
+  #serviceAccountLabels: {}
+
   # Fallback image pull secret.
   # If a pod does not have pull secrets, k8s will use the service account's pull secrets.
   # See: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#serviceaccount-admission-controller
@@ -67,7 +70,7 @@ st2:
   config: |
     [api]
     allow_origin = '*'
-  
+
   #Override Definitions can be added here.
   #https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
   overrides: {}


### PR DESCRIPTION
This PR is about adding the ability to service-account.yaml template to accept custom labels defined through values.yaml

Closes: #326

Use case:
Internally we have a requirement to have a custom label to the service account (SA) in order to get the SA or the pod associated with SA access to internal vault. In other words, when a SA has a specific label, it would help the corresponding pod to obtain access to vault storage.