### PR TITLE
Enable Extra Volumes in Jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Add ability to create custom labels for service account.(#327)(by @SuganJoe)
 * Fix bug that would not set the appropriate redis connection string when using `redis.password` and `redis.usePassword` (#325) (by @rebrowning)
 * New Feature: Add `existingConfigSecret`.  If this is defined, the `st2.secrets.conf` key within this secret will be written as /etc/st2/st2.secrets.conf and added to the end of the command line arguments of all pods. (#289) (by @eric-al/@ericreeves)
-* New Feature: Add `extra_volumes` to all python-based st2 jobs. (by @bmarick)
+* New Feature: Add `extra_volumes` to all python-based st2 jobs. (#333) (by @bmarick)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add ability to create custom labels for service account.(#327)(by @SuganJoe)
 * Fix bug that would not set the appropriate redis connection string when using `redis.password` and `redis.usePassword` (#325) (by @rebrowning)
 * New Feature: Add `existingConfigSecret`.  If this is defined, the `st2.secrets.conf` key within this secret will be written as /etc/st2/st2.secrets.conf and added to the end of the command line arguments of all pods. (#289) (by @eric-al/@ericreeves)
+* New Feature: Add `extra_volumes` to all python-based st2 jobs. (by @bmarick)
 
 ## v0.100.0
 * Switch st2 to `v3.7` as a new default stable version (#274)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -164,10 +164,6 @@ spec:
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
-        {{- range .Values.jobs.extra_volumes }}
-        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
-          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
-        {{- end }}
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
@@ -294,10 +290,6 @@ spec:
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
-        {{- range .Values.jobs.extra_volumes }}
-        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
-          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
-        {{- end }}
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
@@ -352,7 +344,7 @@ spec:
             secretName: {{ .Release.Name }}-st2-kv
         {{- range .Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
-          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+          {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
       restartPolicy: OnFailure
     {{- if .Values.dnsPolicy }}
@@ -428,10 +420,6 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" . | nindent 8 }}
-        {{- range .Values.jobs.extra_volumes }}
-        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
-          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
-        {{- end }}
       {{ end }}
       containers:
       - name: st2-register-content
@@ -473,7 +461,7 @@ spec:
         {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
         {{- range .Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
-          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+          {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
       restartPolicy: OnFailure
     {{- if .Values.dnsPolicy }}
@@ -555,10 +543,6 @@ spec:
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
-        {{- range .Values.jobs.extra_volumes }}
-        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
-          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
-        {{- end }}
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
@@ -613,7 +597,7 @@ spec:
         {{- include "stackstorm-ha.pack-configs-volume" $ | nindent 8 }}
         {{- range .Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
-          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+          {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
       restartPolicy: OnFailure
     {{- if $.Values.dnsPolicy }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -58,6 +58,10 @@ spec:
           mountPath: /opt/stackstorm/rbac/assignments/
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -71,6 +75,10 @@ spec:
         - name: st2-rbac-mappings-vol
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
       restartPolicy: OnFailure
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
@@ -156,6 +164,10 @@ spec:
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
@@ -192,6 +204,10 @@ spec:
         - name: st2-apikeys-vol
           mountPath: /etc/st2/apikeys.yaml
           subPath: apikeys.yaml
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -201,6 +217,10 @@ spec:
         - name: st2-apikeys-vol
           secret:
             secretName: {{ .Release.Name }}-st2-apikeys
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
       restartPolicy: OnFailure
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
@@ -274,6 +294,10 @@ spec:
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
@@ -312,6 +336,10 @@ spec:
         - name: st2-kv-vol
           mountPath: /etc/st2/st2kv.yaml
           subPath: st2kv.yaml
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -322,6 +350,10 @@ spec:
         - name: st2-kv-vol
           secret:
             secretName: {{ .Release.Name }}-st2-kv
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
       restartPolicy: OnFailure
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
@@ -396,6 +428,10 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" . | nindent 8 }}
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
       {{ end }}
       containers:
       - name: st2-register-content
@@ -424,6 +460,10 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -431,6 +471,10 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
       restartPolicy: OnFailure
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
@@ -511,6 +555,10 @@ spec:
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
@@ -548,6 +596,10 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" $ | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" $ | nindent 8 }}
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .resources }}
         resources: {{- toYaml .resources | nindent 10 }}
         {{- end }}
@@ -559,6 +611,10 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" $ | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" $ | nindent 8 }}
+        {{- range .Values.jobs.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
       restartPolicy: OnFailure
     {{- if $.Values.dnsPolicy }}
       dnsPolicy: {{ $.Values.dnsPolicy }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -58,7 +58,7 @@ spec:
           mountPath: /opt/stackstorm/rbac/assignments/
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -75,7 +75,7 @@ spec:
         - name: st2-rbac-mappings-vol
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -200,7 +200,7 @@ spec:
         - name: st2-apikeys-vol
           mountPath: /etc/st2/apikeys.yaml
           subPath: apikeys.yaml
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -213,7 +213,7 @@ spec:
         - name: st2-apikeys-vol
           secret:
             secretName: {{ .Release.Name }}-st2-apikeys
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -328,7 +328,7 @@ spec:
         - name: st2-kv-vol
           mountPath: /etc/st2/st2kv.yaml
           subPath: st2kv.yaml
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -342,7 +342,7 @@ spec:
         - name: st2-kv-vol
           secret:
             secretName: {{ .Release.Name }}-st2-kv
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -448,7 +448,7 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -459,7 +459,7 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -580,7 +580,7 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" $ | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" $ | nindent 8 }}
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in jobs.extra_volumes" .mount | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -595,7 +595,7 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" $ | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" $ | nindent 8 }}
-        {{- range .Values.jobs.extra_volumes }}
+        {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}

--- a/tests/unit/extra_volumes_test.yaml
+++ b/tests/unit/extra_volumes_test.yaml
@@ -1,5 +1,5 @@
 ---
-suite: Custom Annotations
+suite: Extra Volumes
 templates:
   - jobs.yaml
 

--- a/tests/unit/jobs_test.yaml
+++ b/tests/unit/jobs_test.yaml
@@ -1,0 +1,47 @@
+---
+suite: Custom Annotations
+templates:
+  - jobs.yaml
+
+  # included templates must also be listed
+  - configmaps_overrides.yaml
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2-urls.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2apikeys.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+tests:
+  - it: Jobs add extra_volumes
+    template: jobs.yaml
+    set:
+      jobs:
+        extra_volumes:
+          - name: custom-config-map-volume
+            mount:
+              mountPath: /config/config.yml
+              subPath: config.yml
+            volume:
+              configMap:
+                name: customConfig
+    asserts:
+      - hasDocuments:
+          count: 3
+      # job volumeMounts
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom-config-map-volume
+          count: 1
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-config-map-volume
+          count: 1
+          any: true

--- a/values.yaml
+++ b/values.yaml
@@ -88,7 +88,7 @@ st2:
 
 
   # Custom StackStorm config (st2.secrets.conf) which will be created from the key 'st2.secrets.conf' within this secret.
-  # If this is defined, '--config-file=/etc/st2/st2.secrets.conf' will be added to the end of the command line arguments 
+  # If this is defined, '--config-file=/etc/st2/st2.secrets.conf' will be added to the end of the command line arguments
   # for all pods, superseding all other configuration values.
   # This secret must be populated outside of this chart.
   # existingConfigSecret: stackstorm-config-secret
@@ -919,6 +919,10 @@ jobs:
   # HTTP_PROXY: http://proxy:1234
   ## These named secrets (managed outside this chart) will be added to envFrom.
   envFromSecrets: []
+  # mount extra volumes on the st2web pod(s) (primarily useful for k8s-provisioned secrets)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
   #
   # Advanced controls to skip creating jobs.
   # This is useful in targeted upgrades with `--set`. Do not set this in values files.

--- a/values.yaml
+++ b/values.yaml
@@ -919,7 +919,7 @@ jobs:
   # HTTP_PROXY: http://proxy:1234
   ## These named secrets (managed outside this chart) will be added to envFrom.
   envFromSecrets: []
-  # mount extra volumes on the st2web pod(s) (primarily useful for k8s-provisioned secrets)
+  # mount extra volumes on the jobs pods (primarily useful for k8s-provisioned secrets)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
     # see examples under st2actionrunner.extra_volumes


### PR DESCRIPTION
My database connection required me to provide a certificate trust chain to validate the connection.  \
I am able to set that certificate in the deployments by using the `extra_volumes` options in the values file. \
However, the Jobs do not have that option currently available.

This is my attempt to enable the extra_volume support to Jobs.
I have tested the changes in my cluster and validated that the volume mounts worked for my use case. 