### PR TITLE
Switch to `bats-core` for the e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## In Development
-* Switch to `bats-core` for the e2e tests.
+* Switch to the official `bats` Docker image for e2e tests. (#338)
 * Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312 #318) (by @0xhaven)
 * Refactor label definitions to be more consistent by building labels and label selectors in partial helper templates. (#299) (by @cognifloyd)
 * Use the correct `apiVersion` for `Ingress` to add support for Kubernetes `v1.22`. (#301) (by @arms11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Switch to `bats-core` for the e2e tests.
 * Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312 #318) (by @0xhaven)
 * Refactor label definitions to be more consistent by building labels and label selectors in partial helper templates. (#299) (by @cognifloyd)
 * Use the correct `apiVersion` for `Ingress` to add support for Kubernetes `v1.22`. (#301) (by @arms11)

--- a/templates/tests/st2tests-pod.yaml
+++ b/templates/tests/st2tests-pod.yaml
@@ -9,13 +9,28 @@ metadata:
 spec:
   initContainers:
   # Sidecar container to copy BATS framework to the main container
-  - name: test-framework
-    image: dduportal/bats:latest
+  - name: bats-core
+    image: bats/bats:1.8.2
     command:
-      - 'bash'
-      - '-ec'
+      - bash
+      - -ec
       - |
-        cp -R /opt/bats/ ${BATS_HELPERS_DIR} /tools/
+        cp -R /opt/bats /tools/
+    volumeMounts:
+      - name: tools
+        mountPath: /tools
+  - name: bats-addons
+    image: alpine/git:2.36.3
+    command:
+      - ash
+      - -ec
+      - |
+        git clone --config advice.detachedHead=false --depth 1 --branch v0.3.0 \
+          https://github.com/ztombol/bats-assert /tools/bats-assert
+        git clone --config advice.detachedHead=false --depth 1 --branch v0.2.0 \
+          https://github.com/ztombol/bats-file /tools/bats-file
+        git clone --config advice.detachedHead=false --depth 1 --branch v0.3.0 \
+          https://github.com/ztombol/bats-support /tools/bats-support
     volumeMounts:
       - name: tools
         mountPath: /tools
@@ -31,7 +46,7 @@ spec:
         name: {{ .Release.Name }}-st2-auth
     env:
     - name: BATS_HELPERS_DIR
-      value: /tools/bats-helpers/
+      value: /tools
     - name: ST2_VERSION
       value: "{{ .Chart.AppVersion }}"
     - name: ST2_RBAC_ENABLED
@@ -42,7 +57,7 @@ spec:
     - name: tests
       mountPath: /tests
     command:
-      - /tools/bats/libexec/bats
+      - /tools/bats/bin/bats
       - /tests/st2tests.sh
   volumes:
     - name: tools


### PR DESCRIPTION
Switch to `bats-core` for the e2e tests; looks like `dduportal/bats:latest` might not exist on Docker Hub anymore.