### PR TITLE
Set `st2client` resources by `values.yaml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Set `st2client` resources by `values.yaml`. (#337) (by @mamercad)
 * Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312 #318) (by @0xhaven)
 * Refactor label definitions to be more consistent by building labels and label selectors in partial helper templates. (#299) (by @cognifloyd)
 * Use the correct `apiVersion` for `Ingress` to add support for Kubernetes `v1.22`. (#301) (by @arms11)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1653,9 +1653,7 @@ spec:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
         resources:
-          requests:
-            memory: "5Mi"
-            cpu: "5m"
+          {{- toYaml .Values.st2client.resources | nindent 10 }}
       volumes:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol

--- a/values.yaml
+++ b/values.yaml
@@ -797,6 +797,10 @@ st2client:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  resources:
+    requests:
+      memory: "5Mi"
+      cpu: "5m"
 
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.


### PR DESCRIPTION
Set `st2client` resources by `values.yaml`; fixed #337. The e2e tests will hopefully pass after #338 is merged.