### PR TITLE
Add support for providing `ingressClassName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Add support for providing `ingressClassName`. (#336) (by @mamercad)
 * Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312 #318) (by @0xhaven)
 * Refactor label definitions to be more consistent by building labels and label selectors in partial helper templates. (#299) (by @cognifloyd)
 * Use the correct `apiVersion` for `Ingress` to add support for Kubernetes `v1.22`. (#301) (by @arms11)

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
       {{- toYaml .Values.ingress.annotations | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
   - host: {{ .host }}

--- a/values.yaml
+++ b/values.yaml
@@ -289,6 +289,7 @@ ingress:
   # - secretName: chart-example-tls
   #   hosts:
   #     - chart-example.test
+  # ingressClassName: nginx-ingress
 
 ##
 ## NOTE: there used to be a secrets.st2 section here. These values have moved into st2.* above. Please update your values.


### PR DESCRIPTION
Add support for providing `ingressClassName`; fixed #336. The e2e tests will hopefully pass after #338 is merged.