### PR TITLE
Add K3s End-to-End Workflow in GitHub (Experimental)

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,0 +1,115 @@
+name: helm
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Update stackstorm-ha chart dependencies
+        run: |
+          set -x
+          helm dependency update
+
+      - name: Helm lint
+        run: |
+          helm lint
+
+      - name: Cache community
+        id: cache-community
+        uses: actions/cache@v3
+        with:
+          path: community
+          key: ${{ runner.os }}-community-${{ hashFiles('conf/**', 'templates/**', 'Chart.yaml', 'values.yaml') }}
+
+      - name: Helm template
+        if: steps.cache-community.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          helm template --output-dir community .
+
+  k8s-lint:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    needs: [helm-lint]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Cache community
+        id: cache-community
+        uses: actions/cache@v3
+        with:
+          path: community
+          key: ${{ runner.os }}-community-${{ hashFiles('conf/**', 'templates/**', 'Chart.yaml', 'values.yaml') }}
+
+      - name: Kubernetes kubeval lint
+        uses: instrumenta/kubeval-action@master
+        with:
+          files: community
+
+  helm-e2e:
+    needs: [k8s-lint]
+    runs-on: ubuntu-22.04
+    # NOTE: Just a thought in case the timeouts fail; might not be
+    # necessary, but might not hurt either, would vary based on the
+    # size of the testing matrix, too.
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        # TODO: Document which versions we support and cover them.
+        k3s-channel:
+          - "v1.25.4+k3s1"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Set up K3s
+        id: k3s
+        uses: jupyterhub/action-k3s-helm@v3
+        with:
+          k3s-channel: ${{ matrix.k3s-channel }}
+
+      - name: Update stackstorm-ha chart dependencies
+        run: |
+          set -x
+          helm dependency update
+
+      - name: Helm install
+        run: |
+          helm install --timeout 10m0s --debug --wait \
+            --name-template stackstorm-ha .
+
+      - name: Helm test
+        run: |
+          helm test stackstorm-ha
+
+      - name: Helm upgrade with RBAC enabled
+        run: |
+          helm upgrade --set st2.rbac.enabled=true \
+            --timeout 5m0s --debug --wait stackstorm-ha .
+
+      - name: Helm test
+        run: |
+          helm test stackstorm-ha
+
+      - name: Show all Kubernetes resources
+        if: ${{ always() }}
+        run: |
+          kubectl get all

--- a/.github/workflows/lint-and-e2e.yaml
+++ b/.github/workflows/lint-and-e2e.yaml
@@ -1,4 +1,4 @@
-name: helm
+name: Lint & E2E Tests (Experimental)
 
 on:
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## In Development
-* Switch to GitHub and K3s for Helm testing. (#243) (by @mamercad)
+* Add an experimental GitHu/K3s Lint and End-to-End testing workflow. (#243) (by @mamercad)
 * Set `st2client` resources by `values.yaml`. (#337) (by @mamercad)
 * Switch to the official `bats` Docker image for e2e tests. (#338)
 * Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312 #318) (by @0xhaven)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Switch to GitHub and K3s for Helm testing. (#243) (by @mamercad)
 * Temporary workaround for #311 to use previous bitnami index from: https://github.com/bitnami/charts/issues/10539 (#312 #318) (by @0xhaven)
 * Refactor label definitions to be more consistent by building labels and label selectors in partial helper templates. (#299) (by @cognifloyd)
 * Use the correct `apiVersion` for `Ingress` to add support for Kubernetes `v1.22`. (#301) (by @arms11)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # `stackstorm-ha` Helm Chart
-[![Build Status](https://github.com/StackStorm/stackstorm-k8s/actions/workflows/helm.yaml/badge.svg)](https://github.com/StackStorm/stackstorm-k8s/actions/workflows/helm.yaml)
+[![Build Status](https://circleci.com/gh/StackStorm/stackstorm-k8s/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/stackstorm-k8s)
+[![Build Status (Experimental)](https://github.com/StackStorm/stackstorm-k8s/actions/workflows/lint-and-e2e.yaml/badge.svg)](https://github.com/StackStorm/stackstorm-k8s/actions/workflows/lint-and-e2e.yaml)
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stackstorm-ha)](https://artifacthub.io/packages/helm/stackstorm/stackstorm-ha)
 
 K8s Helm Chart for running StackStorm cluster in HA mode.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `stackstorm-ha` Helm Chart
-[![Build Status](https://circleci.com/gh/StackStorm/stackstorm-k8s/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/stackstorm-k8s)
+[![Build Status](https://github.com/StackStorm/stackstorm-k8s/actions/workflows/helm.yaml/badge.svg)](https://github.com/StackStorm/stackstorm-k8s/actions/workflows/helm.yaml)
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stackstorm-ha)](https://artifacthub.io/packages/helm/stackstorm/stackstorm-ha)
 
 K8s Helm Chart for running StackStorm cluster in HA mode.


### PR DESCRIPTION
Add an experimental workflow in GitHub using K3s for testing; fixes #243. Here's an example in my [fork](https://github.com/mamercad/stackstorm-k8s/actions/runs/3731588613/jobs/6330007930).