### PR TITLE
Remove support for networking.k8s.io/v1beta1 removed in k8s v1.22 (already EOL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Drop support for `networking.k8s.io/v1beta1` which was removed in kubernetes v1.22 (EOL 2022-10-28) (#353) (by @cognifloyd)
 * Switch st2 to `v3.8` as a new default stable version (#347)
 * Cover the three most recent Kubernetes versions in Minikube and the single most recent in K3s. (#342) (by @mamercad)
 * Update the GitHub badges. (#345) (by @mamercad)

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.ingress.enabled }}
 ---
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-st2web-ingress

--- a/tests/unit/ingress_test.yaml
+++ b/tests/unit/ingress_test.yaml
@@ -13,11 +13,12 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: Ingress is present when enabled without hosts (older k8s)
-    capabilities: &cap_older
+  - it: Ingress is present when enabled without hosts
+    capabilities: &cap_newer
       majorVersion: 1
-      minorVersion: 18
+      minorVersion: 19
       apiVersions:
+        - networking.k8s.io/v1 # introduced in 1.19, stable in 1.22
         - networking.k8s.io/v1beta1
     set:
       ingress:
@@ -44,42 +45,6 @@ tests:
           count: 1
           content:
             path: "/"
-            backend:
-              serviceName: st2ha-st2web
-              servicePort: 80
-      - isNull:
-          path: spec.rules[0].http.paths[0].pathType
-
-  - it: Ingress is present when enabled without hosts (newer k8s)
-    capabilities: &cap_newer
-      majorVersion: 1
-      minorVersion: 19
-      apiVersions:
-        - networking.k8s.io/v1 # introduced in 1.19, stable in 1.22
-        - networking.k8s.io/v1beta1
-    set:
-      ingress:
-        enabled: true
-        hosts: []
-        tls: []
-      st2web:
-        service:
-          hostname: *st2web_hostname
-    release:
-      name: st2ha
-    asserts:
-      - hasDocuments:
-          count: 1
-      - equal:
-          path: kind
-          value: Ingress
-      # no ingress.hosts, so only st2web.hostname
-      - equal: *st2web_rules_host
-      - contains:
-          path: spec.rules[0].http.paths
-          count: 1
-          content:
-            path: "/"
             pathType: Prefix
             backend:
               service:
@@ -87,12 +52,12 @@ tests:
                 port:
                   number: 80
 
-  - it: Ingress is present when enabled with hosts (older k8s)
-    capabilities: *cap_older
+  - it: Ingress is present when enabled with hosts
+    capabilities: *cap_newer
     set:
       ingress:
         enabled: true
-        hosts: &hosts
+        hosts:
           - host: *st2web_hostname
             paths:
               - serviceName: st2ha-st2web
@@ -114,49 +79,9 @@ tests:
           value: Ingress
       # no ingress.hosts, so only st2web.hostname
       - equal: *st2web_rules_host
-      - equal: &host_path_is_root_glob
+      - equal:
           path: spec.rules[0].http.paths[0].path
           value: "/*"
-      - isNull:
-          path: spec.rules[0].http.paths[0].pathType
-      - equal:
-          path: spec.rules[0].http.paths[0].backend
-          value:
-            serviceName: st2ha-st2web
-            servicePort: 80
-
-      - equal:
-          path: spec.rules[0].http.paths[1].path
-          value: "/fancy-sensor"
-      - isNull:
-          path: spec.rules[0].http.paths[1].pathType
-      - equal:
-          path: spec.rules[0].http.paths[1].backend
-          value:
-            serviceName: fancy-sensor
-            servicePort: 8080
-
-  - it: Ingress is present when enabled with hosts (newer k8s)
-    capabilities: *cap_newer
-    set:
-      ingress:
-        enabled: true
-        hosts: *hosts
-        tls: []
-      st2web:
-        service:
-          hostname: *st2web_hostname
-    release:
-      name: st2ha
-    asserts:
-      - hasDocuments:
-          count: 1
-      - equal:
-          path: kind
-          value: Ingress
-      # no ingress.hosts, so only st2web.hostname
-      - equal: *st2web_rules_host
-      - equal: *host_path_is_root_glob
       - equal:
           path: spec.rules[0].http.paths[0].pathType
           value: Prefix


### PR DESCRIPTION
Closes #331

Our Readme states that we only support the "supported" versions of kubernetes.
Kubernetes 1.22, which dropped support for `networking.k8s.io/v1beta1` is already EOL (as of 2022-10-28).
So, just drop it to bypass the issues identified in #331.
