### PR TITLE
configurable utilityImage + clusterDomain and increase default db timeouts to avoid replicaset timeout

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -103,7 +103,7 @@ Generate comma-separated list of nodes for MongoDB-HA connection string, based o
 {{- range $index0 := until $replicas -}}
   {{- $index1 := $index0 | add1 -}}
   {{- if eq $architecture "replicaset" }}
-    {{- $mongo_fullname }}-{{ $index0 }}.{{ $mongo_fullname }}-headless.{{ $.Release.Namespace }}.svc.cluster.local{{ if ne $index1 $replicas }},{{ end }}
+    {{- $mongo_fullname }}-{{ $index0 }}.{{ $mongo_fullname }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{ if ne $index1 $replicas }},{{ end }}
   {{- else }}
     {{- $mongo_fullname }}-{{ $index0 }}.{{ $mongo_fullname }}{{ if ne $index1 $replicas }},{{ end }}
   {{- end -}}
@@ -122,9 +122,9 @@ Generate list of nodes for Redis with Sentinel connection string, based on numbe
 {{- $sentinel_port := (index .Values "redis" "sentinel" "port") }}
 {{- range $index0 := until $replicas -}}
   {{- if eq $index0 0 -}}
-    {{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless.{{ $.Release.Namespace }}.svc.cluster.local:{{ $sentinel_port }}?sentinel={{ $master_name }}
+    {{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $sentinel_port }}?sentinel={{ $master_name }}
   {{- else -}}
-    &sentinel_fallback={{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless.{{ $.Release.Namespace }}.svc.cluster.local:{{ $sentinel_port }}
+    &sentinel_fallback={{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $sentinel_port }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -46,7 +46,7 @@ Generate Docker utility image line
 {{- if .Values.image.utilityImage -}}
 {{ .Values.image.utilityImage }}
 {{- else -}}
-'docker.io/library/busybox:1.28'
+docker.io/library/busybox:1.28
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -308,7 +308,7 @@ Merge packs and virtualenvs from st2 with those from st2packs images
   {{- if $.Values.st2.packs.images }}
     {{- range $.Values.st2.packs.images }}
 - name: 'st2-custom-pack-{{ printf "%s-%s-%s" .repository .name .tag | sha1sum }}'
-  image: "{{ .registry }}/{{ .repository }}/{{ .name }}:{{ .tag }}"
+  image: "{{ .repository }}/{{ .name }}:{{ .tag }}"
   imagePullPolicy: {{ .pullPolicy | quote }}
   volumeMounts:
   - name: st2-packs-vol

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -40,13 +40,13 @@ app.kubernetes.io/instance: {{ $root.Release.Name }}
 {{- end -}}
 
 {{/*
-Generate Docker image registry: container registry
+Generate Docker utility image line
 */}}
-{{- define "stackstorm-ha.imageRegistry" -}}
-{{- if .Values.image.registry -}}
-{{ .Values.image.registry }}
+{{- define "stackstorm-ha.utilityImage" -}}
+{{- if .Values.image.utilityImage -}}
+{{ .Values.image.utilityImage }}
 {{- else -}}
-'docker.io'
+'docker.io/library/busybox:1.28'
 {{- end -}}
 {{- end -}}
 
@@ -177,7 +177,7 @@ Reduce duplication of the st2.*.conf volume details
 {{- if index .Values "mongodb" "enabled" }}
 {{- $mongodb_port := (int (index .Values "mongodb" "service" "port")) }}
 - name: wait-for-db
-  image: {{ template "stackstorm-ha.imageRegistry" . }}/library/busybox:1.28
+  image: {{ template "stackstorm-ha.utilityImage" . }}
   command:
     - 'sh'
     - '-c'
@@ -197,7 +197,7 @@ Reduce duplication of the st2.*.conf volume details
   {{- if index .Values "rabbitmq" "enabled" }}
     {{- $rabbitmq_port := (int (index .Values "rabbitmq" "service" "port")) }}
 - name: wait-for-queue
-  image: {{ template "stackstorm-ha.imageRegistry" . }}/library/busybox:1.28
+  image: {{ template "stackstorm-ha.utilityImage" . }}
   command:
     - 'sh'
     - '-c'

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -45,7 +45,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       - name: generate-htpasswd
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -62,7 +62,7 @@ spec:
           - printf "${ST2_AUTH_USERNAME}:$(openssl passwd -apr1 "${ST2_AUTH_PASSWORD}")\n" > /tmp/st2/htpasswd
       containers:
       - name: st2auth
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -181,7 +181,7 @@ spec:
       {{- end }}
       containers:
       - name: st2api
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2api:{{ tpl (.Values.st2api.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2api:{{ tpl (.Values.st2api.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -307,7 +307,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2stream
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -407,7 +407,7 @@ spec:
       {{- end }}
       containers:
       - name: st2web
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with default .Values.securityContext .Values.st2web.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -541,7 +541,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2rulesengine
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -658,7 +658,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2timersengine
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -762,7 +762,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2workflowengine
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -878,7 +878,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2scheduler
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -994,7 +994,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2notifier
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1138,7 +1138,7 @@ spec:
       initContainers:
       {{- if $some_sensors_per_pod }}
       - name: {{ $name }}-init-config
-        image: busybox:1.28
+        image: '{{ template "stackstorm-ha.imageRegistry" $ }}/library/busybox:1.28'
         volumeMounts:
         - name: st2-sensor-config-vol
           mountPath: /tmp/st2
@@ -1160,7 +1160,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ $name }}
-        image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2sensorcontainer:{{ tpl ($sensor.image.tag | default $.Values.image.tag) $ }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" $ }}/{{ template "stackstorm-ha.imageRepository" $ }}/st2sensorcontainer:{{ tpl ($sensor.image.tag | default $.Values.image.tag) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
         {{- with default $.Values.securityContext $sensor.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1324,7 +1324,7 @@ spec:
       containers:
       - name: st2actionrunner
         {{- with .Values.st2actionrunner }}
-        image: '{{ .image.repository | default (include "stackstorm-ha.imageRepository" $) }}/{{ .image.name | default "st2actionrunner" }}:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
+        image: '{{ .image.registry | default (include "stackstorm-ha.imageRegistry" $) }}/{{ .image.repository | default (include "stackstorm-ha.imageRepository" $) }}/{{ .image.name | default "st2actionrunner" }}:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
         {{- end }}
         imagePullPolicy: {{ .Values.st2actionrunner.image.pullPolicy | default .Values.image.pullPolicy }}
         {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
@@ -1459,7 +1459,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2garbagecollector
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1572,7 +1572,7 @@ spec:
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1599,7 +1599,7 @@ spec:
             EOT
       containers:
       - name: st2client
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1749,7 +1749,7 @@ spec:
       containers:
       - name: st2chatops
         {{- with .Values.st2chatops }}
-        image: '{{ .image.repository | default (include "stackstorm-ha.imageRepository" $) }}/{{ .image.name | default "st2chatops" }}:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
+        image: '{{ .image.registry | default (include "stackstorm-ha.imageRegistry" $) }}/{{ .image.repository | default (include "stackstorm-ha.imageRepository" $) }}/{{ .image.name | default "st2chatops" }}:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
         {{- end }}
         imagePullPolicy: {{ .Values.st2chatops.image.pullPolicy | default .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -45,7 +45,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       - name: generate-htpasswd
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -62,7 +62,7 @@ spec:
           - printf "${ST2_AUTH_USERNAME}:$(openssl passwd -apr1 "${ST2_AUTH_PASSWORD}")\n" > /tmp/st2/htpasswd
       containers:
       - name: st2auth
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -181,7 +181,7 @@ spec:
       {{- end }}
       containers:
       - name: st2api
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2api:{{ tpl (.Values.st2api.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2api:{{ tpl (.Values.st2api.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -307,7 +307,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2stream
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -407,7 +407,7 @@ spec:
       {{- end }}
       containers:
       - name: st2web
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with default .Values.securityContext .Values.st2web.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -541,7 +541,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2rulesengine
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -658,7 +658,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2timersengine
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -762,7 +762,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2workflowengine
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -878,7 +878,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2scheduler
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -994,7 +994,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2notifier
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1138,7 +1138,7 @@ spec:
       initContainers:
       {{- if $some_sensors_per_pod }}
       - name: {{ $name }}-init-config
-        image: '{{ template "stackstorm-ha.imageRegistry" $ }}/library/busybox:1.28'
+        image: '{{ template "stackstorm-ha.utilityImage" $ }}'
         volumeMounts:
         - name: st2-sensor-config-vol
           mountPath: /tmp/st2
@@ -1160,7 +1160,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ $name }}
-        image: '{{ template "stackstorm-ha.imageRegistry" $ }}/{{ template "stackstorm-ha.imageRepository" $ }}/st2sensorcontainer:{{ tpl ($sensor.image.tag | default $.Values.image.tag) $ }}'
+        image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2sensorcontainer:{{ tpl ($sensor.image.tag | default $.Values.image.tag) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
         {{- with default $.Values.securityContext $sensor.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1324,7 +1324,7 @@ spec:
       containers:
       - name: st2actionrunner
         {{- with .Values.st2actionrunner }}
-        image: '{{ .image.registry | default (include "stackstorm-ha.imageRegistry" $) }}/{{ .image.repository | default (include "stackstorm-ha.imageRepository" $) }}/{{ .image.name | default "st2actionrunner" }}:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
+        image: '{{ .image.repository | default (include "stackstorm-ha.imageRepository" $) }}/{{ .image.name | default "st2actionrunner" }}:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
         {{- end }}
         imagePullPolicy: {{ .Values.st2actionrunner.image.pullPolicy | default .Values.image.pullPolicy }}
         {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
@@ -1459,7 +1459,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2garbagecollector
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1572,7 +1572,7 @@ spec:
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1599,7 +1599,7 @@ spec:
             EOT
       containers:
       - name: st2client
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1749,7 +1749,7 @@ spec:
       containers:
       - name: st2chatops
         {{- with .Values.st2chatops }}
-        image: '{{ .image.registry | default (include "stackstorm-ha.imageRegistry" $) }}/{{ .image.repository | default (include "stackstorm-ha.imageRepository" $) }}/{{ .image.name | default "st2chatops" }}:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
+        image: '{{ .image.repository | default (include "stackstorm-ha.imageRepository" $) }}/{{ .image.name | default "st2chatops" }}:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
         {{- end }}
         imagePullPolicy: {{ .Values.st2chatops.image.pullPolicy | default .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
       - name: st2-apply-rbac-definitions
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -134,7 +134,7 @@ spec:
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       - name: wait-for-api
-        image: {{ template "stackstorm-ha.imageRegistry" . }}/library/busybox:1.28
+        image: {{ template "stackstorm-ha.utilityImage" . }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -147,7 +147,7 @@ spec:
             done
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -174,7 +174,7 @@ spec:
             EOT
       containers:
       - name: st2-apikey-load
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -273,7 +273,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -300,7 +300,7 @@ spec:
             EOT
       containers:
       - name: st2-key-load
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -409,7 +409,7 @@ spec:
       {{- include "stackstorm-ha.packs-initContainers" . | nindent 6 }}
       {{- if $.Values.jobs.preRegisterContentCommand }}
       - name: st2-register-content-custom-init
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -423,7 +423,7 @@ spec:
       {{ end }}
       containers:
       - name: st2-register-content
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -526,7 +526,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-db" $ | nindent 6 }}
       {{- include "stackstorm-ha.packs-initContainers" $ | nindent 6 }}
       - name: generate-st2client-config
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
+        image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
         {{- with $.Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -554,7 +554,7 @@ spec:
             EOT
       containers:
       - name: {{ $name }}
-        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
+        image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
         {{- with $.Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
       - name: st2-apply-rbac-definitions
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -134,7 +134,7 @@ spec:
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       - name: wait-for-api
-        image: busybox:1.28
+        image: {{ template "stackstorm-ha.imageRegistry" . }}/library/busybox:1.28
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -147,7 +147,7 @@ spec:
             done
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -174,7 +174,7 @@ spec:
             EOT
       containers:
       - name: st2-apikey-load
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -273,7 +273,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -300,7 +300,7 @@ spec:
             EOT
       containers:
       - name: st2-key-load
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -409,7 +409,7 @@ spec:
       {{- include "stackstorm-ha.packs-initContainers" . | nindent 6 }}
       {{- if $.Values.jobs.preRegisterContentCommand }}
       - name: st2-register-content-custom-init
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -423,7 +423,7 @@ spec:
       {{ end }}
       containers:
       - name: st2-register-content
-        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -526,7 +526,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-db" $ | nindent 6 }}
       {{- include "stackstorm-ha.packs-initContainers" $ | nindent 6 }}
       - name: generate-st2client-config
-        image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
         {{- with $.Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -554,7 +554,7 @@ spec:
             EOT
       containers:
       - name: {{ $name }}
-        image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
+        image: '{{ template "stackstorm-ha.imageRegistry" . }}/{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
         {{- with $.Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,10 @@
 ## Docker image settings, applied to all StackStorm pods
 ##
 image:
-
+  # utility image to use as sidecar for running startup scripts
+  # allows you to override the registry namespace as well if you are using a private registry
+  # ie
+  # utilityImage: "myprivateregsistry.local/ext.docker.io/library/busybox:1.28"
   utilityImage: ""
   # Image pull policy
   pullPolicy: IfNotPresent
@@ -22,6 +25,12 @@ image:
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   #pullSecret: "your-pull-secret"
 
+##
+## local cluster domain suffix to enable fqdn lookups for redis, mongo
+##  kube-dns defaults to cluster.local and allows override with --domain
+##  core-dns has no default but allows config in k8 configmap
+##    https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#configuration-of-stub-domain-and-upstream-nameserver-using-coredns
+##
 clusterDomain: cluster.local
 
 ##

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,8 @@
 ## Docker image settings, applied to all StackStorm pods
 ##
 image:
+
+  registry: ""
   # Image pull policy
   pullPolicy: IfNotPresent
   # st2 image repository. Set this to override the default ("stackstorm").
@@ -70,6 +72,17 @@ st2:
   config: |
     [api]
     allow_origin = '*'
+    # fixes no replicaset found bug;  
+    [database]
+    # Connection retry backoff max (seconds).
+    connection_retry_backoff_max_s = 10
+    # Backoff multiplier (seconds).
+    connection_retry_backoff_mul = 1
+    # Connection retry total time (minutes).
+    connection_retry_max_delay_m = 3
+    # Connection and server selection timeout (in ms).
+    connection_timeout = 12000
+
 
   #Override Definitions can be added here.
   #https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults

--- a/values.yaml
+++ b/values.yaml
@@ -83,14 +83,8 @@ st2:
     allow_origin = '*'
     # fixes no replicaset found bug;  
     [database]
-    # Connection retry backoff max (seconds).
-    connection_retry_backoff_max_s = 10
-    # Backoff multiplier (seconds).
-    connection_retry_backoff_mul = 1
-    # Connection retry total time (minutes).
-    connection_retry_max_delay_m = 3
     # Connection and server selection timeout (in ms).
-    connection_timeout = 12000
+    connection_timeout = 5000
 
 
   #Override Definitions can be added here.

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@
 ##
 image:
 
-  registry: ""
+  utilityImage: ""
   # Image pull policy
   pullPolicy: IfNotPresent
   # st2 image repository. Set this to override the default ("stackstorm").

--- a/values.yaml
+++ b/values.yaml
@@ -22,7 +22,7 @@ image:
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   #pullSecret: "your-pull-secret"
 
-
+clusterDomain: cluster.local
 
 ##
 ## Service Account


### PR DESCRIPTION
allow alternate proxy registry to be used with helm chart.
fix replica set timeout error
fix dns resolution errors for mongo and redis