### PR TITLE
allow datastore secret name to be specified

### DIFF
--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -7,7 +7,12 @@
 {{- fail "Volume definition(s) missing! When st2.packs.volumes.enabled, you must define volumes for both packs and virtualenvs." }}
   {{- end }}
 {{- end }}
-
+{{- $crypto_key_name := print "no_name" }}
+{{- if eq .Values.st2.datastore_crypto_key_secret_name "no_name" }}
+  {{- $crypto_key_name = print  .Release.Name "-st2-datastore-crypto-key" }}
+{{- else }}
+  {{- $crypto_key_name = print  .Values.st2.datastore_crypto_key_secret_name }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -233,7 +238,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ $crypto_key_name }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -588,7 +593,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ $crypto_key_name }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -809,7 +814,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ $crypto_key_name }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -924,7 +929,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ $crypto_key_name }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -1230,7 +1235,7 @@ spec:
         {{- if ne "disable" (default "" $.Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ $.Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ $crypto_key_name }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -1379,7 +1384,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ $crypto_key_name }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -1658,7 +1663,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ $crypto_key_name }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -3,11 +3,18 @@
 {{- if $deprecated_crypto_key }}
 {{- fail "Please update your values! The datastore_crypto_key value moved from secrets.st2.* to st2.*" }}
 {{- else if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
+
+{{- $name := print "no_name" }}
+{{- if eq .Values.st2.datastore_crypto_key_secret_name "no_name" }}
+  {{- $name = print .Release.Name "-st2-datastore-crypto-key" }}
+{{- else }}
+  {{- $name = print .Values.st2.datstore_crypto_key_secret_name }}
+{{- end }}
+
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  {{- $name := print .Release.Name "-st2-datastore-crypto-key" }}
   name: {{ $name }}
   annotations:
     description: StackStorm crypto key used to encrypt/decrypt KV records
@@ -15,6 +22,7 @@ metadata:
 type: Opaque
 data:
   # Datastore key used to encrypt/decrypt record for the KV store
+{{- if eq .Values.st2.datastore_crypto_key_secret_name "no_name" }}
 {{- $previous := lookup "v1" "Secret" .Release.Namespace $name }}
 {{- if .Values.st2.datastore_crypto_key }}
   datastore_crypto_key: {{ .Values.st2.datastore_crypto_key | b64enc }}
@@ -22,6 +30,8 @@ data:
   datastore_crypto_key: {{ $previous.data.datastore_crypto_key }}
 {{- else }}
   datastore_crypto_key: {{ tpl (.Files.Get "conf/datastore_crypto_key.yaml") . | fromYaml | toRawJson | b64enc }}
+{{- end }}
+
 {{- end }}
 
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -68,6 +68,9 @@ st2:
   # If you want to disable datastore encryption, set "datastore_crypto_key: disable".
   #datastore_crypto_key: >-
   #  {"hmacKey": {"hmacKeyString": "", "size": 256}, "size": 256, "aesKeyString": "", "mode": "CBC"}
+  #  Secret name for existing crypto key.  Setting this to a value will disable key generation.
+  #  This is helpfull if you want to do an uninstall/install of the helm chart
+  datastore_crypto_key_secret_name: "no_name"
   # SSH private key for the 'stanley' system user ('system_user.ssh_key_file' in st2.conf)
   # If set, st2.ssh_key always overrides any existing ssh_key.
   # If not set, the ssh_key is auto-generated on install and preserved across upgrades.


### PR DESCRIPTION
allow a datastore secret name to be specified.  If one is specified do not dynamically generate a new datastore secret.
If I uninstall and reinstall this helm chart a new secret is generated.
Sometimes a helm upgrade isn't enough.  In that case I do an uninstall and reinstall.  This seems to be the case for ingress changes.