### PR TITLE
add external secret for datastore encryption

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -35,7 +35,7 @@ jobs:
         # We should periodically check to see if another fork has taken over maintenance,
         # as the de-facto "best" fork has changed several times over the years.
         run: |
-          helm plugin install https://github.com/quintush/helm-unittest
+          helm plugin install https://github.com/quintush/helm-unittest --version v0.2.11
 
       - name: Install chart dependencies
         run: |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -78,6 +78,14 @@ Create the name of the stackstorm-ha st2 auth secret to use
 {{- default $name .Values.st2.existingAuthSecret -}}
 {{- end -}}
 
+{{/*
+Create the name of the stackstorm-ha st2 datastore secret to use
+*/}}
+{{- define "stackstorm-ha.secrets.st2Datastore" -}}
+{{- $name := print .Release.Name "-st2-datastore" -}}
+{{- default $name .Values.st2.existingDatastoreSecret -}}
+{{- end -}}
+
 
 {{/*
 Generate '-' prefix only when the variable is defined

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -82,7 +82,7 @@ Create the name of the stackstorm-ha st2 auth secret to use
 Create the name of the stackstorm-ha st2 datastore secret to use
 */}}
 {{- define "stackstorm-ha.secrets.st2Datastore" -}}
-{{- $name := print .Release.Name "-st2-datastore" -}}
+{{- $name := print .Release.Name "-st2-datastore-crypto-key" -}}
 {{- default $name .Values.st2.existingDatastoreSecret -}}
 {{- end -}}
 

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -233,7 +233,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ include "stackstorm-ha.secrets.st2Datastore" . }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -588,7 +588,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ include "stackstorm-ha.secrets.st2Datastore" . }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -809,7 +809,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ include "stackstorm-ha.secrets.st2Datastore" . }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -924,7 +924,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ include "stackstorm-ha.secrets.st2Datastore" . }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -1230,7 +1230,7 @@ spec:
         {{- if ne "disable" (default "" $.Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ $.Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ include "stackstorm-ha.secrets.st2Datastore" $ }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -1379,7 +1379,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ include "stackstorm-ha.secrets.st2Datastore" . }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
@@ -1658,7 +1658,7 @@ spec:
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
+            secretName: {{ include "stackstorm-ha.secrets.st2Datastore" . }}
             items:
             - key: datastore_crypto_key
               path: datastore_key.json

--- a/values.yaml
+++ b/values.yaml
@@ -64,6 +64,8 @@ st2:
   #password: Ch@ngeMe
   # Name of existing ST2 Auth secret, disables creation of this secret
   # existingAuthSecret: ""
+  # Name of existing ST2 datastore secret, disables creation of this secret
+  # existingDatastoreSecret: ""
 
   # ST2 crypto key for the  K/V datastore.
   # See https://docs.stackstorm.com/datastore.html#securing-secrets-admin-only for more info.


### PR DESCRIPTION
add an external secret check to values.yaml to allow for secret to be stored outside of helm chart.