### PR TITLE
fix: PVC should use `claimName` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,10 @@ For example, to use persistentVolumeClaims:
     enabled: true
     packs:
       persistentVolumeClaim:
-        claim-name: pvc-st2-packs
+        claimName: pvc-st2-packs
     virtualenvs:
       persistentVolumeClaim:
-        claim-name: pvc-st2-virtualenvs
+        claimName: pvc-st2-virtualenvs
 ```
 
 Or, for example, to use NFS:
@@ -286,7 +286,7 @@ For example, to use persistentVolumeClaims:
     ... # define packs and virtualenvs volumes as shown above
     configs:
       persistentVolumeClaim:
-        claim-name: pvc-st2-pack-configs
+        claimName: pvc-st2-pack-configs
 ```
 
 Or, for example, to use NFS:

--- a/values.yaml
+++ b/values.yaml
@@ -174,7 +174,7 @@ st2:
 
         # example using persistentVolumeClaim:
         #persistentVolumeClaim:
-        #  claim-name: pvc-st2-packs
+        #  claimName: pvc-st2-packs
 
         # example using NFS:
         #nfs:


### PR DESCRIPTION
When using `claim-name` for persistent pack volumes, the following error is raised by Helm:

```
> helm upgrade my-st2 stackstorm/stackstorm-ha --values values.yaml --debug
upgrade.go:144: [debug] preparing upgrade for my-st2
Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(Deployment.spec.template.spec.volumes[2].persistentVolumeClaim): unknown field "claim-name" in io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource, ValidationError(Deployment.spec.template.spec.volumes[2].persistentVolumeClaim): missing required field "claimName" in io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource, ValidationError(Deployment.spec.template.spec.volumes[3].persistentVolumeClaim): unknown field "claim-name" in io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource, ValidationError(Deployment.spec.template.spec.volumes[3].persistentVolumeClaim): missing required field "claimName" in io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource, ValidationError(Deployment.spec.template.spec.volumes[4].persistentVolumeClaim): unknown field "claim-name" in io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource, ValidationError(Deployment.spec.template.spec.volumes[4].persistentVolumeClaim): missing required field "claimName" in io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource]
```

Fix by using `claimName` instead for `persistentVolumeClaim` sections.