### PR TITLE
Remove redundant [credentials] header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reduce duplication in label tests (#354) (by @cognifloyd)
 * Add `st2canary` job as a Helm Hook that runs before install/upgrade to ensure `st2.packs.volumes` is configured correctly (if `st2.packs.volumes.enabled`). (#323) (by @cognifloyd)
 * Enable using existing `st2-auth` secret. This allows users to manage this secret outside of the Helm process. (#359) (by @bmarick)
+* Fix st2 client config issue affecting addon jobs using jobs.extra_hooks (#370) (by @cars)
 
 ## v0.110.0
 * Switch st2 to `v3.8` as a new default stable version (#347)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -661,7 +661,6 @@ spec:
           - '-ec'
           - |
             cat <<EOT > /root/.st2/config
-            [credentials]
             {{- tpl $.Values.jobs.st2clientConfig $ | nindent 12 }}
             EOT
       containers:


### PR DESCRIPTION
Remove redundant [credentials] header for client config that causes st2 commands to fail.
Closes #370 