### PR TITLE
add pod graceful timeout override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reduce duplication in label tests (#354) (by @cognifloyd)
 * Add `st2canary` job as a Helm Hook that runs before install/upgrade to ensure `st2.packs.volumes` is configured correctly (if `st2.packs.volumes.enabled`). (#323) (by @cognifloyd)
 * Enable using existing `st2-auth` secret. This allows users to manage this secret outside of the Helm process. (#359) (by @bmarick)
+* Add terminationGracePeriodSeconds to workflow and actionrunner pods to allow adjustment of grace period in k8 (#374) (by @guzzijones12)
 
 ## v0.110.0
 * Switch st2 to `v3.8` as a new default stable version (#347)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -753,6 +753,7 @@ spec:
           {{- toYaml .Values.st2workflowengine.annotations | nindent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.st2workflowengine.terminationGracePeriodSeconds | default 300 }}
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
@@ -1321,6 +1322,7 @@ spec:
       {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
         {{- include "stackstorm-ha.packs-initContainers" . | nindent 6 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.st2actionrunner.terminationGracePeriodSeconds | default 300 }}
       containers:
       - name: st2actionrunner
         {{- with .Values.st2actionrunner }}

--- a/values.yaml
+++ b/values.yaml
@@ -563,6 +563,7 @@ st2timersengine:
 # https://docs.stackstorm.com/reference/ha.html#st2workflowengine
 # Multiple st2workflowengine processes can run in active-active mode and will share the load and pick up more work if one or more of the processes become available.
 st2workflowengine:
+  #terminationGracePeriodSeconds: 350
   replicas: 2
   resources:
     requests:
@@ -657,6 +658,7 @@ st2notifier:
 # Multiple st2actionrunner processes can run in active-active with only connections to MongoDB and RabbitMQ. Work gets naturally
 # distributed across runners via RabbitMQ. Adding more st2actionrunner processes increases the ability of StackStorm to execute actions.
 st2actionrunner:
+  #terminationGracePeriodSeconds: 350
   replicas: 5
   resources:
     requests:

--- a/values.yaml
+++ b/values.yaml
@@ -563,7 +563,8 @@ st2timersengine:
 # https://docs.stackstorm.com/reference/ha.html#st2workflowengine
 # Multiple st2workflowengine processes can run in active-active mode and will share the load and pick up more work if one or more of the processes become available.
 st2workflowengine:
-  #terminationGracePeriodSeconds: 350
+  # include some small explanation about this setting
+  terminationGracePeriodSeconds: 300
   replicas: 2
   resources:
     requests:

--- a/values.yaml
+++ b/values.yaml
@@ -563,7 +563,7 @@ st2timersengine:
 # https://docs.stackstorm.com/reference/ha.html#st2workflowengine
 # Multiple st2workflowengine processes can run in active-active mode and will share the load and pick up more work if one or more of the processes become available.
 st2workflowengine:
-  # include some small explanation about this setting
+  # k8 pod timeout.  set this to a few seconds longer than st2 config workflow_engine.exit_still_active_check
   terminationGracePeriodSeconds: 300
   replicas: 2
   resources:
@@ -659,6 +659,8 @@ st2notifier:
 # Multiple st2actionrunner processes can run in active-active with only connections to MongoDB and RabbitMQ. Work gets naturally
 # distributed across runners via RabbitMQ. Adding more st2actionrunner processes increases the ability of StackStorm to execute actions.
 st2actionrunner:
+  # k8 pod timeout.  set this to a few seconds longer than st2 config actionrunner.exit_still_active_check and set
+  # actionrunner.graceful_shutdown = True
   terminationGracePeriodSeconds: 300
   replicas: 5
   resources:

--- a/values.yaml
+++ b/values.yaml
@@ -659,7 +659,7 @@ st2notifier:
 # Multiple st2actionrunner processes can run in active-active with only connections to MongoDB and RabbitMQ. Work gets naturally
 # distributed across runners via RabbitMQ. Adding more st2actionrunner processes increases the ability of StackStorm to execute actions.
 st2actionrunner:
-  #terminationGracePeriodSeconds: 350
+  terminationGracePeriodSeconds: 300
   replicas: 5
   resources:
     requests:


### PR DESCRIPTION
add graceful timeout option for pods.
this will allow a user to override it in values.yaml.

we need this to to  along with the graceful timeout settings in st2actionrunner and st2workflowengine.