### PR TITLE
prevent init containers from persisting across helm upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reduce duplication in label tests (#354) (by @cognifloyd)
 * Add `st2canary` job as a Helm Hook that runs before install/upgrade to ensure `st2.packs.volumes` is configured correctly (if `st2.packs.volumes.enabled`). (#323) (by @cognifloyd)
 * Enable using existing `st2-auth` secret. This allows users to manage this secret outside of the Helm process. (#359) (by @bmarick)
+* Prevent duplicate init containers on helm upgrade (#375) (by @guzzijones12)
 
 ## v0.110.0
 * Switch st2 to `v3.8` as a new default stable version (#347)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -322,7 +322,7 @@ Merge packs and virtualenvs from st2 with those from st2packs images
 {{- define "stackstorm-ha.packs-initContainers" -}}
   {{- if $.Values.st2.packs.images }}
     {{- range $.Values.st2.packs.images }}
-- name: 'st2-custom-pack-{{ printf "%s-%s-%s" .repository .name .tag | sha1sum }}'
+- name: 'st2-custom-pack-{{ printf "%s-%s-%s" .repository .name | sha1sum }}'
   image: "{{ .repository }}/{{ .name }}:{{ .tag }}"
   imagePullPolicy: {{ .pullPolicy | quote }}
   volumeMounts:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -322,7 +322,7 @@ Merge packs and virtualenvs from st2 with those from st2packs images
 {{- define "stackstorm-ha.packs-initContainers" -}}
   {{- if $.Values.st2.packs.images }}
     {{- range $.Values.st2.packs.images }}
-- name: 'st2-custom-pack-{{ printf "%s-%s-%s" .repository .name | sha1sum }}'
+- name: 'st2-custom-pack-{{ printf "%s-%s" .repository .name | sha1sum }}'
   image: "{{ .repository }}/{{ .name }}:{{ .tag }}"
   imagePullPolicy: {{ .pullPolicy | quote }}
   volumeMounts:


### PR DESCRIPTION
this pr prevents st2packs init containers from persisting across upgrades.
fixes #260