### PR TITLE
Update K8s to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           command: helm dependency update
       - run:
           name: Helm install stackstorm-ha chart
-          command: helm install --timeout 10m0s --debug --wait --name-template stackstorm-ha .
+          command: helm install --timeout 20m0s --debug --wait --name-template stackstorm-ha .
       - run:
           name: Helm test
           command: helm test stackstorm-ha
@@ -66,7 +66,6 @@ workflows:
                 - "v1.28.3"
                 - "v1.27.7"
                 - "v1.26.10"
-                - "v1.25.15"
   # Run periodic nightly Helm tests to ensure there are no regressions
   e2e-nightly:
     jobs:
@@ -78,7 +77,6 @@ workflows:
                 - "v1.28.3"
                 - "v1.27.7"
                 - "v1.26.10"
-                - "v1.25.15"
     triggers:
       - schedule:
           cron: "0 1 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 # Add additional CircleCI Orbs dependencies
 orbs:
   # https://circleci.com/orbs/registry/orb/circleci/kubernetes
-  kubernetes: circleci/kubernetes@0.11.0
+  kubernetes: circleci/kubernetes@1.3.1
   # https://circleci.com/orbs/registry/orb/circleci/helm
-  helm: circleci/helm@1.1.1
+  helm: circleci/helm@3.0.0
   # https://circleci.com/orbs/registry/orb/ccpgames/minikube
   minikube: ccpgames/minikube@0.0.1
 
@@ -21,13 +21,13 @@ jobs:
     resource_class: large
     machine:
       # Available images https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:current
     steps:
       - checkout
       - kubernetes/install
       - minikube/minikube-install:
           # https://github.com/kubernetes/minikube/releases
-          version: v1.29.0
+          version: v1.31.2
       - run:
           name: Install Helm v3
           command: curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
@@ -63,9 +63,10 @@ workflows:
             parameters:
               # https://kubernetes.io/releases
               kubernetes-version:
-                - "v1.26.1"
-                - "v1.25.5"
-                - "v1.24.9"
+                - "v1.28.3"
+                - "v1.27.7"
+                - "v1.26.10"
+                - "v1.25.15"
   # Run periodic nightly Helm tests to ensure there are no regressions
   e2e-nightly:
     jobs:
@@ -74,9 +75,10 @@ workflows:
             parameters:
               # https://kubernetes.io/releases
               kubernetes-version:
-                - "v1.26.1"
-                - "v1.25.5"
-                - "v1.24.9"
+                - "v1.28.3"
+                - "v1.27.7"
+                - "v1.26.10"
+                - "v1.25.15"
     triggers:
       - schedule:
           cron: "0 1 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           command: helm dependency update
       - run:
           name: Helm install stackstorm-ha chart
-          command: helm install --timeout 20m0s --debug --wait --name-template stackstorm-ha .
+          command: helm install --timeout 15m0s --debug --wait --name-template stackstorm-ha .
       - run:
           name: Helm test
           command: helm test stackstorm-ha

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Helm install
         run: |
-          helm install --timeout 20m0s --debug --wait \
+          helm install --timeout 15m0s --debug --wait \
             --name-template stackstorm-ha .
 
       - name: Helm test

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,7 +28,7 @@ jobs:
         # https://github.com/StackStorm/stackstorm-k8s/issues/342
         # https://github.com/k3s-io/k3s/releases
         k3s-channel:
-          - "v1.26.1+k3s1"
+          - "v1.28.3+k3s1"
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
 
       - name: Helm install
         run: |
-          helm install --timeout 10m0s --debug --wait \
+          helm install --timeout 20m0s --debug --wait \
             --name-template stackstorm-ha .
 
       - name: Helm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
 ## In Development
-* Bump to latest CircleCI orb versions (by @ZoeLeah)
-* Remove unsupported k8s Versions (by @ZoeLeah)
+* Bump to latest CircleCI orb versions (kubernetes@1.3.1 and helm@3.0.0 by @ZoeLeah)
+* Remove unsupported k8s Versions (1.24.x and 1.25.x by @ZoeLeah)
+* Update and add new K8s versions (1.28.3, 1.27.7 and 1.26.10 by @ZoeLeah)
+* Switch from ubuntu-2204:2022.10.2 to ubuntu-2204:current (by @ZoeLeah)
+* Update K3s to v1.28.3+k3s1 (by @ZoeLeah)
+* Increase helm install timeout to 15 minutes (by @ZoeLeah)
 * Shift K3s and K8s versions forward. (by @mamercad)
 * BREAKING: Use the standardized labels recommended in the Helm docs. You can use `migrations/v1.0/standardize-labels.sh` to prepare an existing cluster before running `helm update`. (#351) (by @cognifloyd)
 * Drop support for `networking.k8s.io/v1beta1` which was removed in kubernetes v1.22 (EOL 2022-10-28) (#353) (by @cognifloyd)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## In Development
+* Bump to latest CircleCI orb versions (by @ZoeLeah)
+* Remove unsupported k8s Versions (by @ZoeLeah)
 * Shift K3s and K8s versions forward. (by @mamercad)
 * BREAKING: Use the standardized labels recommended in the Helm docs. You can use `migrations/v1.0/standardize-labels.sh` to prepare an existing cluster before running `helm update`. (#351) (by @cognifloyd)
 * Drop support for `networking.k8s.io/v1beta1` which was removed in kubernetes v1.22 (EOL 2022-10-28) (#353) (by @cognifloyd)

--- a/migrations/v1.0/standardize-labels.sh
+++ b/migrations/v1.0/standardize-labels.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# We switched to the standard labels recommend in Helm's "Best Practices" doc.                                  
+# We switched to the standard labels recommend in Helm's "Best Practices" doc.
 # https://helm.sh/docs/chart_best_practices/labels/#standard-labels
 #
 # This script adds those labels to all the resources in an existing release,

--- a/tests/unit/ingress_test.yaml
+++ b/tests/unit/ingress_test.yaml
@@ -8,7 +8,7 @@ tests:
   - it: Ingress not present if disabled
     set:
       ingress:
-        enabled: false 
+        enabled: false
     asserts:
       - hasDocuments:
           count: 0

--- a/tests/unit/overrides_test.yaml
+++ b/tests/unit/overrides_test.yaml
@@ -43,7 +43,6 @@ tests:
     asserts:
       - hasDocuments:
           count: 5
-
       - contains: &overrides_volume
           path: spec.template.spec.volumes
           content:
@@ -51,20 +50,16 @@ tests:
             configMap:
               name: st2ha-st2-overrides-configs
         documentIndex: 3 # register_content
-
-   
       - contains: &overrides_mnt
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: st2-overrides-vol
             mountPath: /opt/stackstorm/overrides
         documentIndex: 3 # register_content
-      
       - contains: *overrides_mnt
         documentIndex: 4 #Extra_jobs
       - contains: *overrides_volume
         documentIndex: 4 #extra_jobs
-
       - notContains: *overrides_volume
         documentIndex: 0
       - notContains: *overrides_mnt
@@ -78,7 +73,7 @@ tests:
       - notContains: *overrides_mnt
         documentIndex: 2
 
-  
+
   - it: Deployments with overrides
     template: deployments.yaml
     set:
@@ -102,14 +97,10 @@ tests:
     asserts:
       - hasDocuments:
           count: 14
-
-
       - contains: *overrides_volume # always included
         documentIndex: 12 # st2client
       - contains: *overrides_mnt # always included
         documentIndex: 12 # st2client
-
-     
       - notContains: *overrides_volume
         documentIndex: 1
       - notContains: *overrides_mnt

--- a/tests/unit/post_start_script_test.yaml
+++ b/tests/unit/post_start_script_test.yaml
@@ -267,4 +267,3 @@ tests:
       - equal: *assert_lifecycle
       - contains: *assert_volume_mount
       - contains: *assert_volume
-

--- a/tests/unit/service_account_test.yaml
+++ b/tests/unit/service_account_test.yaml
@@ -198,4 +198,3 @@ tests:
         documentIndex: 11
       - equal: *assert_sa_custom
         documentIndex: 13
-

--- a/tests/unit/services_test.yaml
+++ b/tests/unit/services_test.yaml
@@ -8,13 +8,13 @@ tests:
   - it: st2web, st2auth, st2api, st2stream should work without externalName
     set:
       st2chatops:
-        enabled: false 
+        enabled: false
     asserts:
       - hasDocuments:
           count: 4
       - isNull:
           path: spec.externalName
-  
+
   - it: st2web, st2auth, st2api, st2stream should work with externalName if type is ExternalName
     set:
       st2web:
@@ -34,7 +34,7 @@ tests:
           hostname: some-host-name
           type: ExternalName
       st2chatops:
-        enabled: false 
+        enabled: false
     asserts:
       - hasDocuments:
           count: 4
@@ -44,4 +44,3 @@ tests:
       - equal:
           path: spec.externalName
           value: some-host-name
-


### PR DESCRIPTION
The following changes have been made:

- Update to latest CircleCI orb versions
- Switch image from ubuntu-2204:2022.10.2 to ubuntu-2204:current to have always the latest ubuntu version
- Increase helm install timeout to 20 minutes
- Update to latest k8s and remove unsupported versions