### PR TITLE
Presleep for st2auth, st2web, st2api, st2stream

### DIFF
--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -101,7 +101,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2auth.preStopSleep | default 10 }} ]
+              command: [ "sleep", {{ .Values.st2auth.preStopSleep | default "10" }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -231,7 +231,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2api.preStopSleep | default 10 }} ]
+              command: [ "sleep", {{ .Values.st2api.preStopSleep | default "10" }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -354,7 +354,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2stream.preStopSleep | default 10 }} ]
+              command: [ "sleep", {{ .Values.st2stream.preStopSleep | default "10" }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -438,7 +438,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2web.preStopSleep | default 10 }} ]
+              command: [ "sleep", {{ .Values.st2web.preStopSleep | default "10" }} ]
         # Probe to check if app is running. Failure will lead to a pod restart.
         livenessProbe:
           httpGet:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -60,6 +60,7 @@ spec:
           - 'sh'
           - '-ec'
           - printf "${ST2_AUTH_USERNAME}:$(openssl passwd -apr1 "${ST2_AUTH_PASSWORD}")\n" > /tmp/st2/htpasswd
+      terminationGracePeriodSeconds: {{ .Values.st2auth.terminationGracePeriodSeconds | default 30 }}
       containers:
       - name: st2auth
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
@@ -179,6 +180,7 @@ spec:
       {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
         {{- include "stackstorm-ha.packs-initContainers" . | nindent 6 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.st2api.terminationGracePeriodSeconds | default 30 }}
       containers:
       - name: st2api
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2api:{{ tpl (.Values.st2api.image.tag | default .Values.image.tag) . }}'
@@ -220,6 +222,9 @@ spec:
           mountPath: /post-start.sh
           subPath: post-start.sh
         lifecycle:
+          preStop:
+            exec:
+              command: [ "sleep", {{ .Values.st2.st2api.preStopSleep }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -317,7 +317,7 @@ spec:
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
-      terminationGracePeriodSeconds: {{ .Values.st2workflowengine.terminationGracePeriodSeconds | default 30 }}
+      terminationGracePeriodSeconds: {{ .Values.st2stream.terminationGracePeriodSeconds | default 30 }}
       containers:
       - name: st2stream
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
@@ -354,7 +354,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2.st2api.preStopSleep | default 10 }} ]
+              command: [ "sleep", {{ .Values.st2.st2stream.preStopSleep | default 10 }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -423,7 +423,7 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.st2api.terminationGracePeriodSeconds | default 30 }}
+      terminationGracePeriodSeconds: {{ .Values.st2web.terminationGracePeriodSeconds | default 30 }}
       containers:
       - name: st2web
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -433,12 +433,6 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 443 80 }}
-        lifecycle:
-          preStop:
-            exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
-              # kubeproxy and kubelet both race  
-              # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2web.preStopSleep | toString }} ]
         # Probe to check if app is running. Failure will lead to a pod restart.
         livenessProbe:
           httpGet:
@@ -482,6 +476,11 @@ spec:
             mountPath: /post-start.sh
             subPath: post-start.sh
         lifecycle:
+          preStop:
+            exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
+              # kubeproxy and kubelet both race  
+              # wait a bit to ensure kubeproxy has removed the iptables rule.
+              command: [ "sleep", {{ .Values.st2web.preStopSleep | toString }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -101,7 +101,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2.st2auth.preStopSleep | default 10 }} ]
+              command: [ "sleep", {{ .Values.st2auth.preStopSleep | default 10 }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -231,7 +231,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2.st2api.preStopSleep | default 10 }} ]
+              command: [ "sleep", {{ .Values.st2api.preStopSleep | default 10 }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -354,7 +354,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2.st2stream.preStopSleep | default 10 }} ]
+              command: [ "sleep", {{ .Values.st2stream.preStopSleep | default 10 }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -438,7 +438,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2.st2web.preStopSleep | default 10 }} ]
+              command: [ "sleep", {{ .Values.st2web.preStopSleep | default 10 }} ]
         # Probe to check if app is running. Failure will lead to a pod restart.
         livenessProbe:
           httpGet:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -97,6 +97,11 @@ spec:
           mountPath: /post-start.sh
           subPath: post-start.sh
         lifecycle:
+          preStop:
+            exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
+              # kubeproxy and kubelet both race  
+              # wait a bit to ensure kubeproxy has removed the iptables rule.
+              command: [ "sleep", {{ .Values.st2.st2auth.preStopSleep | default 10 }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -223,8 +228,10 @@ spec:
           subPath: post-start.sh
         lifecycle:
           preStop:
-            exec:
-              command: [ "sleep", {{ .Values.st2.st2api.preStopSleep }} ]
+            exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
+              # kubeproxy and kubelet both race  
+              # wait a bit to ensure kubeproxy has removed the iptables rule.
+              command: [ "sleep", {{ .Values.st2.st2api.preStopSleep | default 10 }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -310,6 +317,7 @@ spec:
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
+      terminationGracePeriodSeconds: {{ .Values.st2workflowengine.terminationGracePeriodSeconds | default 30 }}
       containers:
       - name: st2stream
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
@@ -342,6 +350,11 @@ spec:
           mountPath: /post-start.sh
           subPath: post-start.sh
         lifecycle:
+          preStop:
+            exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
+              # kubeproxy and kubelet both race  
+              # wait a bit to ensure kubeproxy has removed the iptables rule.
+              command: [ "sleep", {{ .Values.st2.st2api.preStopSleep | default 10 }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -410,6 +423,7 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.st2api.terminationGracePeriodSeconds | default 30 }}
       containers:
       - name: st2web
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
@@ -419,6 +433,12 @@ spec:
         {{- end }}
         ports:
         - containerPort: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 443 80 }}
+        lifecycle:
+          preStop:
+            exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
+              # kubeproxy and kubelet both race  
+              # wait a bit to ensure kubeproxy has removed the iptables rule.
+              command: [ "sleep", {{ .Values.st2.st2web.preStopSleep | default 10 }} ]
         # Probe to check if app is running. Failure will lead to a pod restart.
         livenessProbe:
           httpGet:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -101,7 +101,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2auth.preStopSleep | default "10" }} ]
+              command: [ "sleep", {{ .Values.st2auth.preStopSleep | toString }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -231,7 +231,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2api.preStopSleep | default "10" }} ]
+              command: [ "sleep", {{ .Values.st2api.preStopSleep | toString }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -354,7 +354,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2stream.preStopSleep | default "10" }} ]
+              command: [ "sleep", {{ .Values.st2stream.preStopSleep | toString }} ]
           postStart:
             exec:
               command: ["/bin/bash", "/post-start.sh"]
@@ -438,7 +438,7 @@ spec:
             exec: # https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da
               # kubeproxy and kubelet both race  
               # wait a bit to ensure kubeproxy has removed the iptables rule.
-              command: [ "sleep", {{ .Values.st2web.preStopSleep | default "10" }} ]
+              command: [ "sleep", {{ .Values.st2web.preStopSleep | toString }} ]
         # Probe to check if app is running. Failure will lead to a pod restart.
         livenessProbe:
           httpGet:

--- a/values.yaml
+++ b/values.yaml
@@ -381,7 +381,7 @@ st2web:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
-  preStopSleep: 10
+  preStopSleep: "10"
 
 # https://docs.stackstorm.com/reference/ha.html#st2auth
 # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
@@ -417,7 +417,7 @@ st2auth:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
-  preStopSleep: 10
+  preStopSleep: "10"
   # mount extra volumes on the st2auth pod(s) (primarily useful for custom logging conf)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
@@ -457,7 +457,7 @@ st2api:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
-  preStopSleep: 10
+  preStopSleep: "10"
   # mount extra volumes on the st2api pod(s) (primarily useful for custom logging conf)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
@@ -497,7 +497,7 @@ st2stream:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
-  preStopSleep: 10
+  preStopSleep: "10"
   # mount extra volumes on the st2stream pod(s) (primarily useful for custom logging conf)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []

--- a/values.yaml
+++ b/values.yaml
@@ -381,6 +381,7 @@ st2web:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  preStopSleep: 10
 
 # https://docs.stackstorm.com/reference/ha.html#st2auth
 # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
@@ -416,6 +417,7 @@ st2auth:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  preStopSleep: 10
   # mount extra volumes on the st2auth pod(s) (primarily useful for custom logging conf)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
@@ -455,6 +457,7 @@ st2api:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  preStopSleep: 10
   # mount extra volumes on the st2api pod(s) (primarily useful for custom logging conf)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
@@ -494,6 +497,7 @@ st2stream:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  preStopSleep: 10
   # mount extra volumes on the st2stream pod(s) (primarily useful for custom logging conf)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []


### PR DESCRIPTION
kubeproxy and kubelet race to shutdown and update firewall rules.  This PR gives kubeproxy a bit of time to update it's firewall rules.  
[pod deletes notify k8 api server and kubelet at the same time](https://blog.laputa.io/graceful-shutdown-in-kubernetes-85f1c8d586da)