### PR TITLE
Update the Chart Maintainers - the StackStorm Authors

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -20,9 +20,9 @@ keywords:
   - IFTTT
   - HA
 maintainers:
-  - name: Eugen Cusmaunsa
-    email: armab@stackstorm.com
-    url: https://github.com/armab
+  - name: The StackStorm Authors
+    email: info@stackstorm.com
+    url: https://github.com/StackStorm
 details:
   This Helm chart is a fully installable app that codifies StackStorm cluster deployment optimized for HA and K8s environment.
   RabbitMQ-HA, MongoDB-HA clusters and Redis coordination backend st2 relies on will be deployed as 3rd party chart dependencies.


### PR DESCRIPTION
Update the chart Maintainers to be "the StackStorm Authors".
This is a common name used everywhere across the org since the LF transition: https://github.com/StackStorm/st2/blob/master/st2api/st2api/app.py#L1C17-L1C40

Shared contact would suit better, as seen in many other OSS projects/repos.