### PR TITLE
Stop generating the checksum labels for Auth Secret when existing secret provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix syntax with ensure-packs-volumes-are-writable job (#403) (by @skiedude)
 * Add securityContext support to custom st2packs images, extra_hooks jobs; Also fallback to st2actionrunner securityContext for misc init container jobs and pods. (#410) (by @cognifloyd)
 * Stop generating the DataStore Secret (#385) and checksum labels (#391) when existing secret provided or disabled (by @bmarick)
+* Stop generating the checksum labels for Auth Secret (#392) when existing secret provided or disabled (by @bmarick)
 
 ## v1.0.0
 * Bump to latest CircleCI orb versions (kubernetes@1.3.1 and helm@3.0.0 by @ZoeLeah)
@@ -21,7 +22,6 @@
 * Add terminationGracePeriodSeconds to workflow and actionrunner pods to allow adjustment of grace period in k8 (#374) (by @guzzijones12)
 * Prevent duplicate init containers on helm upgrade (#375) (by @guzzijones12)
 * Fix st2 client config issue affecting addon jobs using jobs.extra_hooks (#370) (by @cars)
-* Stop generating the checksum labels for Auth Secret (#392) when existing secret provided or disabled (by @bmarick)
 
 ## v0.110.0
 * Switch st2 to `v3.8` as a new default stable version (#347)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add terminationGracePeriodSeconds to workflow and actionrunner pods to allow adjustment of grace period in k8 (#374) (by @guzzijones12)
 * Prevent duplicate init containers on helm upgrade (#375) (by @guzzijones12)
 * Fix st2 client config issue affecting addon jobs using jobs.extra_hooks (#370) (by @cars)
+* Stop generating the checksum labels for Auth Secret (#392) when existing secret provided or disabled (by @bmarick)
 
 ## v0.110.0
 * Switch st2 to `v3.8` as a new default stable version (#347)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -28,7 +28,9 @@ spec:
       labels: {{- include "stackstorm-ha.labels" (list $ "st2auth") | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if not .Values.st2.existingAuthSecret }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.st2auth.postStartScript }}
         checksum/post-start-script: {{ .Values.st2auth.postStartScript | sha256sum }}
         {{- end }}
@@ -1572,7 +1574,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/rbac: {{ include (print $.Template.BasePath "/configmaps_rbac.yaml") . | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") . | sha256sum }}
+        {{- if not .Values.st2.existingAuthSecret }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
+        {{- end }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
         {{- if .Values.st2.overrides }}


### PR DESCRIPTION
These labels are not needed when an existing secret is provided.
So removing them from the templated output.

Related to issue #393 