### PR TITLE
Allow templating of st2.packs.configs in values.yaml

### DIFF
--- a/templates/configmaps_packs.yaml
+++ b/templates/configmaps_packs.yaml
@@ -7,4 +7,4 @@ metadata:
     description: StackStorm pack configs defined in helm values, shipped in (or copied to) '/opt/stackstorm/configs/'
   labels: {{- include "stackstorm-ha.labels" (list $ "st2") | nindent 4 }}
 data:
-{{ toYaml .Values.st2.packs.configs | indent 2 }}
+{{ tpl (toYaml .Values.st2.packs.configs) . | indent 2 }}


### PR DESCRIPTION
As it says on the tin.

Allows the use of go templating in the `st2.packs.configs` value when creating the Configs ConfigMap