### PR TITLE
Add image pull policy to all containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add securityContext support to custom st2packs images, extra_hooks jobs; Also fallback to st2actionrunner securityContext for misc init container jobs and pods. (#410) (by @cognifloyd)
 * Stop generating the DataStore Secret (#385) and checksum labels (#391) when existing secret provided or disabled (by @bmarick)
 * Stop generating the checksum labels for Auth Secret (#392) when existing secret provided or disabled (by @bmarick)
+* Use `image.pullPolicy` for all containers including init containers that use `image.utilityImage`. (#397) (by @jk464)
 
 ## v1.0.0
 * Bump to latest CircleCI orb versions (kubernetes@1.3.1 and helm@3.0.0 by @ZoeLeah)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -196,6 +196,7 @@ Reduce duplication of the st2.*.conf volume details
 {{- $mongodb_port := (int (index .Values "mongodb" "service" "port")) }}
 - name: wait-for-db
   image: {{ template "stackstorm-ha.utilityImage" . }}
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
   command:
     - 'sh'
     - '-c'
@@ -216,6 +217,7 @@ Reduce duplication of the st2.*.conf volume details
     {{- $rabbitmq_port := (int (index .Values "rabbitmq" "service" "port")) }}
 - name: wait-for-queue
   image: {{ template "stackstorm-ha.utilityImage" . }}
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
   command:
     - 'sh'
     - '-c'

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1164,6 +1164,7 @@ spec:
       {{- if $some_sensors_per_pod }}
       - name: {{ $name }}-init-config
         image: '{{ template "stackstorm-ha.utilityImage" $ }}'
+        imagePullPolicy: {{ $.Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-sensor-config-vol
           mountPath: /tmp/st2

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -135,6 +135,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       - name: wait-for-api
         image: {{ template "stackstorm-ha.utilityImage" . }}
+        imagePullPolicy: {{ $.Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
Some containers where missing the ability to specify an `imagePullPolicy`. This adds in those missing options, and matches the global `image`'s Pull Policy.