### PR TITLE
Run Containers as Non-Root, and without Privilege Escalation by default.

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -342,8 +342,8 @@ Merge packs and virtualenvs from st2 with those from st2packs images
     - 'sh'
     - '-ec'
     - |
-      /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-      /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      /bin/cp -dR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
+      /bin/cp -dR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
   {{- with $.Values.securityContext }}
   securityContext: {{- toYaml . | nindent 8 }}
   {{- end }}
@@ -363,8 +363,8 @@ Merge packs and virtualenvs from st2 with those from st2packs images
     - 'sh'
     - '-ec'
     - |
-      /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-      /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      /bin/cp -dR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
+      /bin/cp -dR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
   {{- with .Values.securityContext }}
   securityContext: {{- toYaml . | nindent 8 }}
   {{- end }}
@@ -383,7 +383,7 @@ Merge packs and virtualenvs from st2 with those from st2packs images
     - 'sh'
     - '-ec'
     - |
-      /bin/cp -aR /opt/stackstorm/configs/. /opt/stackstorm/configs-shared
+      /bin/cp -dR /opt/stackstorm/configs/. /opt/stackstorm/configs-shared
   {{- with .Values.securityContext }}
   securityContext: {{- toYaml . | nindent 8 }}
   {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -432,13 +432,13 @@ spec:
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         ports:
-        - containerPort: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 443 80 }}
+        - containerPort: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 8443 8080 }}
         # Probe to check if app is running. Failure will lead to a pod restart.
         livenessProbe:
           httpGet:
             scheme: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary "HTTPS" "HTTP" }}
             path: /
-            port: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 443 80 }}
+            port: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 8443 8080 }}
           initialDelaySeconds: 1
         # Probe to check if app is ready to serve traffic. Failure will lead to temp stop serving traffic.
         # TODO: Failing to add readinessProbe, since st2 requires authorization (401) and we don't have `/healthz` endpoints yet (https://github.com/StackStorm/st2/issues/4020)
@@ -1614,13 +1614,13 @@ spec:
         {{- end }}
         volumeMounts:
         - name: st2client-config-vol
-          mountPath: /root/.st2/
+          mountPath: /home/stanley/.st2/
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
           - '-ec'
           - |
-            cat <<EOT > /root/.st2/config
+            cat <<EOT > /home/stanley/.st2/config
             {{- tpl .Values.st2client.st2clientConfig . | nindent 12 }}
             EOT
       containers:
@@ -1653,7 +1653,7 @@ spec:
         {{- end }}
         {{- include "stackstorm-ha.overrides-config-mounts" . | nindent 8 }}
         - name: st2client-config-vol
-          mountPath: /root/.st2/
+          mountPath: /home/stanley/.st2/
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -163,13 +163,13 @@ spec:
         {{- end }}
         volumeMounts:
         - name: st2client-config-vol
-          mountPath: /root/.st2/
+          mountPath: /home/stanley/.st2/
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
           - '-ec'
           - |
-            cat <<EOT > /root/.st2/config
+            cat <<EOT > /home/stanley/.st2/config
             {{- tpl .Values.jobs.st2clientConfig . | nindent 12 }}
             EOT
       containers:
@@ -196,7 +196,7 @@ spec:
         {{- end }}
         volumeMounts:
         - name: st2client-config-vol
-          mountPath: /root/.st2/
+          mountPath: /home/stanley/.st2/
         - name: st2-apikeys-vol
           mountPath: /etc/st2/apikeys.yaml
           subPath: apikeys.yaml
@@ -289,13 +289,13 @@ spec:
         {{- end }}
         volumeMounts:
         - name: st2client-config-vol
-          mountPath: /root/.st2/
+          mountPath: /home/stanley/.st2/
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
           - '-ec'
           - |
-            cat <<EOT > /root/.st2/config
+            cat <<EOT > /home/stanley/.st2/config
             {{- tpl .Values.jobs.st2clientConfig . | nindent 12 }}
             EOT
       containers:
@@ -324,7 +324,7 @@ spec:
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         - name: st2client-config-vol
-          mountPath: /root/.st2/
+          mountPath: /home/stanley/.st2/
         - name: st2-kv-vol
           mountPath: /etc/st2/st2kv.yaml
           subPath: st2kv.yaml
@@ -654,13 +654,13 @@ spec:
         {{- end }}
         volumeMounts:
         - name: st2client-config-vol
-          mountPath: /root/.st2/
+          mountPath: /home/stanley/.st2/
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
         command:
           - 'sh'
           - '-ec'
           - |
-            cat <<EOT > /root/.st2/config
+            cat <<EOT > /home/stanley/.st2/config
             {{- tpl $.Values.jobs.st2clientConfig $ | nindent 12 }}
             EOT
       containers:
@@ -686,7 +686,7 @@ spec:
         {{- end }}
         volumeMounts:
         - name: st2client-config-vol
-          mountPath: /root/.st2/
+          mountPath: /home/stanley/.st2/
         {{- include "stackstorm-ha.overrides-config-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" $ | nindent 8 }}

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -100,7 +100,7 @@ spec:
   {{- end }}
   ports:
   - protocol: TCP
-    port: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 443 80 }}
+    port: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 8443 8080 }}
 
 {{ if .Values.st2chatops.enabled -}}
 ---

--- a/values.yaml
+++ b/values.yaml
@@ -290,8 +290,11 @@ st2:
 ## Default SecurityContext for pods and containers.
 ## Overrides available for st2web, st2actionrunner, st2sensorcontainer, and st2client pods.
 ##
-podSecurityContext: {}
-securityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+securityContext:
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
 
 ##
 ## StackStorm HA Ingress
@@ -367,7 +370,10 @@ st2web:
     attach: false
   # override the default .podSecurityContext or .securityContext here
   podSecurityContext: {}
-  securityContext: {}  # NB: nginx requires some capabilities, drop ALL will cause issues.
+  securityContext: # NB: nginx requires some capabilities, drop ALL will cause issues.
+    runAsUser: 101  # run as nginx user
+    runAsGroup: 101 # run as nginx group
+    allowPrivilegeEscalation: false 
   # mount extra volumes on the st2web pod(s) (primarily useful for k8s-provisioned secrets)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
@@ -1038,6 +1044,15 @@ mongodb:
   arbiter:
     enabled: false
   resources: {}
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+    sysctls: []
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
 
 ##
 ## RabbitMQ configuration (3rd party chart dependency)
@@ -1085,7 +1100,12 @@ rabbitmq:
   # As RabbitMQ enabled prometheus operator monitoring by default, disable it for non-prometheus users
   metrics:
     enabled: false
-
+  podSecurityContext:
+    fsGroup: 1001
+    runAsUser: 1001
+    runAsNonRoot: true
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
 ##
 ## Redis HA configuration (3rd party chart dependency)
 ##
@@ -1121,6 +1141,14 @@ redis:
   usePassword: false
   metrics:
     enabled: false
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsNonRoot: true
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    allowPrivilegeEscalation: false
 
 ##
 ## Settings to be applied to all stackstorm-ha pods


### PR DESCRIPTION
In attempt to harden the security of running StackStorm within k8s, this PR makes it such that by default all containers run as a non-root user, generally `1000:1000` (the `stanley` user) - or for `st2web` it runs as `100:100` (which is the `nginx` user).

It also disables the ability of the container to escalate privileges.

 Generally in my testing, this all "just" works - Aside from requiring a change to the `st2web` container to allow `nginx` to run as the `nginx` user. (Changes to support that are here https://github.com/StackStorm/st2-dockerfiles/pull/66).

NOTE: This PR depends on https://github.com/StackStorm/st2-dockerfiles/pull/66 to work.