### PR TITLE
Enabled internal TLS between k8s pods by default

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -411,3 +411,21 @@ Create the custom env list for each deployment
   value: {{ $value | quote }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Set up values for Internal TLS
+*/}}
+{{- define "stackstorm-ha.internal_tls.cert_volume.mount" -}}
+{{- if or .Values.st2.tls.enabled .Values.mongodb.tls.enabled .Values.rabbitmq.tls.enabled }}
+- name: {{ .Values.st2.tls.secretName }}
+  mountPath: {{ .Values.st2.tls.mountPath }}/
+  readOnly: true
+{{- end }}
+{{- end -}}
+{{- define "stackstorm-ha.internal_tls.cert_volume.volume" -}}
+{{- if or .Values.st2.tls.enabled .Values.mongodb.tls.enabled .Values.rabbitmq.tls.enabled }}
+- name: {{ .Values.st2.tls.secretName }}
+  secret:
+    secretName: {{ .Values.st2.tls.secretName }}
+{{- end }}
+{{- end -}}

--- a/templates/ca.yaml
+++ b/templates/ca.yaml
@@ -1,0 +1,21 @@
+{{- if not ( .Values.st2.tls.certificate_issuer.existing ) -}}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.st2.tls.certificate_issuer.name }}
+  namespace: "{{ $.Release.Namespace }}"
+spec:
+  ca:
+    secretName: {{ .Values.st2.tls.certificate_issuer.name }}-tls
+---
+apiVersion: v1
+data:
+  tls.crt: "{{ .Values.secret.ca.crt }}"
+  tls.key: "{{ .Values.secret.ca.key }}"
+kind: Secret
+metadata:
+  name: {{ .Values.st2.tls.certificate_issuer.name }}-tls
+  namespace: "{{ $.Release.Namespace }}"
+type: kubernetes.io/tls
+{{- end -}}

--- a/templates/certificate.yaml
+++ b/templates/certificate.yaml
@@ -1,0 +1,28 @@
+{{- if or .Values.st2.tls.enabled .Values.mongodb.tls.enabled .Values.rabbitmq.tls.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.st2.tls.secretName }}
+  labels:
+    app: stackstorm
+    heritage: {{.Release.Service | quote}}
+    release: {{.Release.Name | quote}}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+spec:
+  secretName: {{ .Values.st2.tls.secretName }}
+  dnsNames:
+    - "*.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}"
+{{ include "stackstorm-ha.mongodb-nodes" $ | splitList "," | toYaml | indent 4 }}
+  ipAddresses:
+    - "127.0.0.1"
+  renewBefore: 360h # 15d
+  privateKey:
+    rotationPolicy: Always
+    algorithm: RSA
+    size: 3072
+  issuerRef:
+    name: {{ .Values.st2.tls.certificate_issuer.name }}
+    kind: Issuer
+    group: cert-manager.io
+{{- end -}}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -11,7 +11,11 @@ data:
   # The order of merging: st2.conf < st2.docker.conf < st2.user.conf
   st2.docker.conf: |
     [auth]
+    {{- if .Values.rabbitmq.tls.enabled }}
+    api_url = https://{{ .Release.Name }}-st2api:9111/
+    {{- else }}
     api_url = http://{{ .Release.Name }}-st2api:9101/
+    {{- end -}}
     [system_user]
     user = {{ .Values.st2.system_user.user }}
     ssh_key_file = {{ tpl .Values.st2.system_user.ssh_key_file . }}
@@ -21,7 +25,11 @@ data:
     {{- end }}
     {{- if index .Values "rabbitmq" "enabled" }}
     [messaging]
+    {{- if .Values.rabbitmq.tls.enabled }}
+    url = amqp://{{ required "rabbitmq.auth.username is required!" (index .Values "rabbitmq" "auth" "username") }}:{{ required "rabbitmq.auth.password is required!" (index .Values "rabbitmq" "auth" "password") }}@{{ .Release.Name }}-rabbitmq:5671{{ required "rabbitmq.ingress.path is required!" (index .Values "rabbitmq" "ingress" "path") }}
+    {{- else }}
     url = amqp://{{ required "rabbitmq.auth.username is required!" (index .Values "rabbitmq" "auth" "username") }}:{{ required "rabbitmq.auth.password is required!" (index .Values "rabbitmq" "auth" "password") }}@{{ .Release.Name }}-rabbitmq:5672{{ required "rabbitmq.ingress.path is required!" (index .Values "rabbitmq" "ingress" "path") }}
+    {{- end -}}
     {{- end }}
     {{- if index .Values "mongodb" "enabled" }}
     [database]

--- a/templates/configmaps_st2-urls.yaml
+++ b/templates/configmaps_st2-urls.yaml
@@ -7,6 +7,18 @@ metadata:
     description: StackStorm service URLs, used across entire st2 cluster
   labels: {{- include "stackstorm-ha.labels" (list $ "st2") | nindent 4 }}
 data:
+  {{- if and .Values.st2.tls.enabled .Values.st2auth.tls.enabled }}
+  ST2_AUTH_URL: https://{{ .Release.Name }}-st2auth:9100/
+  {{- else }}
   ST2_AUTH_URL: http://{{ .Release.Name }}-st2auth:9100/
+  {{- end }}
+  {{- if and .Values.st2.tls.enabled .Values.st2api.tls.enabled }}
+  ST2_API_URL: https://{{ .Release.Name }}-st2api:9111/
+  {{- else }}
   ST2_API_URL: http://{{ .Release.Name }}-st2api:9101/
+  {{- end }}
+  {{- if and .Values.st2.tls.enabled .Values.st2stream.tls.enabled }}
+  ST2_STREAM_URL: https://{{ .Release.Name }}-st2stream:9112/
+  {{- else }}
   ST2_STREAM_URL: http://{{ .Release.Name }}-st2stream:9102/
+  {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -83,6 +83,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8  }}
         - name: htpasswd-vol
           mountPath: /etc/st2/htpasswd
@@ -112,6 +113,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         - name: htpasswd-vol
           emptyDir:
@@ -193,8 +195,11 @@ spec:
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{/* When using internal TLS don't expose API Port outside pod */}}
+        {{- if not (and .Values.st2.tls.enabled .Values.st2api.tls.enabled) }}
         ports:
         - containerPort: 9101
+        {{- end }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -208,6 +213,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
@@ -238,10 +244,45 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.st2api.resources | nindent 10 }}
+      {{- if and .Values.st2.tls.enabled .Values.st2api.tls.enabled }}
+      # StackStorm doesn't provide TLS for the API endpoint.
+      # Therefore when using Internal TLS, we need use ghostunnel (https://github.com/ghostunnel/ghostunnel) to provide a TLS proxy layer
+      - name: tls-proxy
+        image: {{ .Values.ghostunnel.image.repository }}/{{ .Values.ghostunnel.image.name }}:{{ .Values.ghostunnel.image.tag }}
+        imagePullPolicy: {{ .Values.ghostunnel.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        args:
+          - server
+          - --listen=:9111
+          - --target=127.0.0.1:9101
+          - --key={{ .Values.st2.tls.mountPath }}/tls.key
+          - --cert={{ .Values.st2.tls.mountPath }}/tls.crt
+          - --disable-authentication
+        resources:
+          requests:
+            memory: 25Mi
+            cpu: 100m
+          limits:
+            memory: 50Mi
+            cpu: 200m
+        ports:
+        - containerPort: 9111
+          name: https
+          protocol: TCP
+        volumeMounts:
+          {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 10  }}
+          {{- range .Values.st2api.extra_volumes }}
+          - name: {{ required "Each volume must have a 'name' in st2api.extra_volumes" .name }}
+            {{- tpl (required "Each volume must have a 'mount' definition in st2api.extra_volumes" .mount | toYaml) $ | nindent 12 }}
+          {{- end }}
+      {{- end }}
     {{- if .Values.st2api.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
@@ -325,8 +366,11 @@ spec:
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{/* When using internal TLS don't expose Stream Port outside pod */}}
+        {{- if not (and .Values.st2.tls.enabled .Values.st2stream.tls.enabled) }}
         ports:
         - containerPort: 9102
+        {{- end }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -340,6 +384,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- range .Values.st2stream.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2stream.extra_volumes" .name }}
@@ -361,10 +406,45 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.st2stream.resources | nindent 10 }}
+      {{- if and .Values.st2.tls.enabled .Values.st2stream.tls.enabled }}
+      # StackStorm doesn't provide TLS for the Stream endpoint.
+      # Therefore when using Internal TLS, we need use ghostunnel (https://github.com/ghostunnel/ghostunnel) to provide a TLS proxy layer
+      - name: tls-proxy
+        image: {{ .Values.ghostunnel.image.repository }}/{{ .Values.ghostunnel.image.name }}:{{ .Values.ghostunnel.image.tag }}
+        imagePullPolicy: {{ .Values.ghostunnel.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        args:
+          - server
+          - --listen=:9112
+          - --target=127.0.0.1:9102
+          - --key={{ .Values.st2.tls.mountPath }}/tls.key
+          - --cert={{ .Values.st2.tls.mountPath }}/tls.crt
+          - --disable-authentication
+        resources:
+          requests:
+            memory: 25Mi
+            cpu: 100m
+          limits:
+            memory: 50Mi
+            cpu: 200m
+        ports:
+        - containerPort: 9112
+          name: https
+          protocol: TCP
+        volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
+          {{- range .Values.st2stream.extra_volumes }}
+          - name: {{ required "Each volume must have a 'name' in st2stream.extra_volumes" .name }}
+            {{- tpl (required "Each volume must have a 'mount' definition in st2stream.extra_volumes" .mount | toYaml) $ | nindent 12 }}
+          {{- end }}
+      {{- end }}
     {{- if .Values.st2stream.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- range .Values.st2stream.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2stream.extra_volumes" .name }}
@@ -432,13 +512,13 @@ spec:
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         ports:
-        - containerPort: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 443 80 }}
+        - containerPort: {{ if and .Values.st2.tls.enabled .Values.st2web.tls.enabled -}}8443{{- else -}}8080{{- end }}
         # Probe to check if app is running. Failure will lead to a pod restart.
         livenessProbe:
           httpGet:
-            scheme: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary "HTTPS" "HTTP" }}
+            scheme: {{ if and .Values.st2.tls.enabled .Values.st2web.tls.enabled -}}HTTPS{{- else -}}HTTP{{- end }}
             path: /
-            port: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 443 80 }}
+            port: {{ if and .Values.st2.tls.enabled .Values.st2web.tls.enabled -}}8443{{- else -}}8080{{- end }}
           initialDelaySeconds: 1
         # Probe to check if app is ready to serve traffic. Failure will lead to temp stop serving traffic.
         # TODO: Failing to add readinessProbe, since st2 requires authorization (401) and we don't have `/healthz` endpoints yet (https://github.com/StackStorm/st2/issues/4020)
@@ -451,8 +531,13 @@ spec:
 #            path: /api/
 #            port: 443
 #          initialDelaySeconds: 3
+        env:
         {{- if .Values.st2web.env }}
-        env: {{- include "stackstorm-ha.customEnv" .Values.st2web | nindent 8 }}
+        {{- include "stackstorm-ha.customEnv" .Values.st2web | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.st2.tls.enabled .Values.st2web.tls.enabled }}
+        - name: "ST2WEB_HTTPS"
+          value: "1"
         {{- end }}
         envFrom:
         - configMapRef:
@@ -462,6 +547,7 @@ spec:
     {{- else }}
         volumeMounts: []
     {{- end }}
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 10  }}
         {{- range .Values.st2web.extra_volumes }}
           - name: {{ required "Each volume must have a 'name' in st2web.extra_volumes" .name }}
             {{- tpl (required "Each volume must have a 'mount' definition in st2web.extra_volumes" .mount | toYaml) $ | nindent 12 }}
@@ -495,6 +581,7 @@ spec:
     {{- else }}
       volumes: []
     {{- end }}
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- range .Values.st2web.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2web.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in st2web.extra_volumes" .volume | toYaml) $ | nindent 10 }}
@@ -583,6 +670,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
@@ -608,6 +696,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
@@ -700,6 +789,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- range .Values.st2timersengine.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2timersengine.extra_volumes" .name }}
@@ -720,6 +810,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- range .Values.st2timersengine.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2timersengine.extra_volumes" .name }}
@@ -805,6 +896,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
@@ -830,6 +922,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
@@ -921,6 +1014,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
@@ -946,6 +1040,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
@@ -1037,6 +1132,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- range .Values.st2notifier.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2notifier.extra_volumes" .name }}
@@ -1057,6 +1153,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- range .Values.st2notifier.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2notifier.extra_volumes" .name }}
@@ -1220,6 +1317,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" $ | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts" $ | nindent 8 }}
         {{- if $some_sensors_per_pod }}
@@ -1252,6 +1350,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" $ }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" $ | nindent 8  }}
         {{- if ne "disable" (default "" $.Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
@@ -1373,6 +1472,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
@@ -1402,6 +1502,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
@@ -1503,6 +1604,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- range .Values.st2garbagecollector.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2garbagecollector.extra_volumes" .name }}
@@ -1523,6 +1625,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- range .Values.st2garbagecollector.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2garbagecollector.extra_volumes" .name }}
@@ -1642,6 +1745,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.rbac.enabled }}
         - name: st2-rbac-roles-vol
@@ -1681,6 +1785,7 @@ spec:
         resources:
           {{- toYaml .Values.st2client.resources | nindent 10 }}
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -51,6 +51,7 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-rbac-roles-vol
           mountPath: /opt/stackstorm/rbac/roles/
@@ -65,6 +66,7 @@ spec:
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         - name: st2-rbac-roles-vol
           configMap:
@@ -142,7 +144,11 @@ spec:
           - 'sh'
           - '-c'
           - >
+            {{- if and .Values.st2.tls.enabled .Values.st2api.tls.enabled }}
+            until nc -z -w 2 {{ .Release.Name }}-st2api 9111 && echo st2api ready;
+            {{- else }}
             until nc -z -w 2 {{ .Release.Name }}-st2api 9101 && echo st2api ready;
+            {{- end }}
               do sleep 2;
             done
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
@@ -162,6 +168,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
@@ -195,6 +202,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-apikeys-vol
@@ -207,6 +215,7 @@ spec:
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
@@ -288,6 +297,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
@@ -322,6 +332,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
@@ -335,6 +346,7 @@ spec:
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         - name: st2client-config-vol
           emptyDir:
@@ -416,6 +428,7 @@ spec:
         {{- end }}
         command: {{- toYaml $.Values.jobs.preRegisterContentCommand | nindent 8 }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.overrides-config-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
@@ -444,6 +457,7 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.overrides-config-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" . | nindent 8 }}
@@ -455,6 +469,7 @@ spec:
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.overrides-configs" . | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
@@ -562,6 +577,7 @@ spec:
             done
             echo DONE
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.packs-volume-mounts" $ | nindent 8 }}
         {{/* do not include the pack-configs-volume-mount helper here */}}
         - name: st2-pack-configs-vol
@@ -570,6 +586,7 @@ spec:
         # TODO: Find out default resource limits for this specific job (#5)
         #resources:
       volumes:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.packs-volumes" $ | nindent 8 }}
         {{- if $.Values.st2.packs.volumes.configs }}
           {{/* do not include the pack-configs-volume helper here */}}
@@ -653,6 +670,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
         # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
@@ -687,6 +705,7 @@ spec:
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
+        {{- include "stackstorm-ha.internal_tls.cert_volume.mount" . | nindent 8  }}
         {{- include "stackstorm-ha.overrides-config-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" $ | nindent 8 }}
@@ -702,6 +721,7 @@ spec:
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
+        {{- include "stackstorm-ha.internal_tls.cert_volume.volume" . | nindent 8  }}
         {{- include "stackstorm-ha.overrides-configs" $ | nindent 8 }}
         {{- include "stackstorm-ha.st2-config-volume" $ | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" $ | nindent 8 }}

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -48,7 +48,11 @@ spec:
   {{- end }}
   ports:
   - protocol: TCP
+    {{- if and .Values.st2.tls.enabled .Values.st2api.tls.enabled }}
+    port: 9111
+    {{- else }}
     port: 9101
+    {{- end }}
 
 ---
 kind: Service
@@ -74,7 +78,11 @@ spec:
   {{- end }}
   ports:
   - protocol: TCP
+    {{- if and .Values.st2.tls.enabled .Values.st2stream.tls.enabled }}
+    port: 9112
+    {{- else }}
     port: 9102
+    {{- end }}
 
 ---
 kind: Service
@@ -99,8 +107,10 @@ spec:
   {{- end }}
   {{- end }}
   ports:
-  - protocol: TCP
-    port: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 443 80 }}
+  - name: st2web
+    protocol: TCP
+    port: {{ if and .Values.st2.tls.enabled .Values.st2web.tls.enabled -}}8443{{- else -}}8080{{- end }}
+    targetPort: {{ if and .Values.st2.tls.enabled .Values.st2web.tls.enabled -}}8443{{- else -}}8080{{- end }}
 
 {{ if .Values.st2chatops.enabled -}}
 ---

--- a/values.yaml
+++ b/values.yaml
@@ -88,10 +88,41 @@ st2:
     [api]
     allow_origin = '*'
     # fixes no replicaset found bug;
+
     [database]
     # Connection and server selection timeout (in ms).
     connection_timeout = 5000
+    {{- if .Values.mongodb.tls.enabled }}
+    ssl = True
+    ssl_ca_certs = {{ .Values.st2.tls.mountPath }}/ca.crt
+    ssl_cert_reqs = optional
+    ssl_certfile = {{ .Values.st2.tls.mountPath }}/tls.crt
+    ssl_keyfile = {{ .Values.st2.tls.mountPath }}/tls.key
+    {{- else }}
+    ssl = False
+    {{- end }}
 
+    [messaging]
+    {{- if .Values.rabbitmq.tls.enabled }}
+    ssl = True
+    ssl_ca_certs = {{ .Values.st2.tls.mountPath }}/ca.crt
+    ssl_cert_reqs = optional
+    ssl_certfile = {{ .Values.st2.tls.mountPath }}/tls.crt
+    ssl_keyfile = {{ .Values.st2.tls.mountPath }}/tls.key
+    {{- else }}
+    ssl = False
+    {{- end }}
+
+    [auth]
+    {{- if and .Values.st2.tls.enabled .Values.st2auth.tls.enabled }}
+    use_ssl = True
+    key = {{ .Values.st2.tls.mountPath }}/tls.key
+    cert = {{ .Values.st2.tls.mountPath }}/tls.crt
+    debug = False
+    enable = True
+    {{- else }}
+    use_ssl = False
+    {{- end }}
 
   #Override Definitions can be added here.
   #https://docs.stackstorm.com/latest/packs.html#overriding-pack-defaults
@@ -286,6 +317,15 @@ st2:
       #  roles:
       #    - "admin"
 
+  # Controls configuring TLS between internal inter-pod communications
+  tls:
+    enabled: true
+    secretName: "internal-tls"
+    mountPath: "/etc/ssl/internal"
+    certificate_issuer:
+      existing: false
+      name: stackstorm-issuer
+
 ##
 ## Default SecurityContext for pods and containers.
 ## Overrides available for st2web, st2actionrunner, st2sensorcontainer, and st2client pods.
@@ -370,7 +410,19 @@ st2web:
   securityContext: {}  # NB: nginx requires some capabilities, drop ALL will cause issues.
   # mount extra volumes on the st2web pod(s) (primarily useful for k8s-provisioned secrets)
   ## Note that Helm templating is supported in 'mount' and 'volume'
-  extra_volumes: []
+  extra_volumes:
+    - name: st2-cert
+      mount:
+        mountPath: "/etc/ssl/st2/"
+        readOnly: true
+      volume:
+        secret:
+          secretName: "stackstorm-tls{{if .Values.phaseCanary}}-canary{{end}}"
+          items:
+          - key: tls.crt
+            path: st2.crt
+          - key: tls.key
+            path: st2.key
     # see examples under st2actionrunner.extra_volumes
   # User-defined st2web config with custom settings to replace default config.js
   # See https://github.com/StackStorm/st2web#connecting-to-st2-server for more info
@@ -382,6 +434,9 @@ st2web:
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
   preStopSleep: "10"
+  # Use TLS on HTTP connections to st2web (i.e. between pod and ingress)
+  tls:
+    enabled: true
 
 # https://docs.stackstorm.com/reference/ha.html#st2auth
 # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
@@ -422,6 +477,9 @@ st2auth:
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
     # see examples under st2actionrunner.extra_volumes
+  # Use TLS on HTTP connections to st2auth (i.e. between pod and ingress, and inter-pod)
+  tls:
+    enabled: true
 
 # https://docs.stackstorm.com/reference/ha.html#st2api
 # Multiple st2api process can be behind a load balancer in an active-active configuration.
@@ -462,6 +520,9 @@ st2api:
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
     # see examples under st2actionrunner.extra_volumes
+  # Use TLS on HTTP connections to st2api (i.e. between pod and ingress, and inter-pod)
+  tls:
+    enabled: true
 
 # https://docs.stackstorm.com/reference/ha.html#st2stream
 # Multiple st2stream process can be behind a load balancer in an active-active configuration.
@@ -502,6 +563,9 @@ st2stream:
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
     # see examples under st2actionrunner.extra_volumes
+  # Use TLS on HTTP connections to st2stream (i.e. between pod and ingress, and inter-pod)
+  tls:
+    enabled: true
 
 # https://docs.stackstorm.com/reference/ha.html#st2rulesengine
 # Multiple st2rulesengine processes can run in active-active with only connections to MongoDB and RabbitMQ. All these will share the TriggerInstance load and naturally pick up more work if one or more of the processes becomes unavailable.
@@ -1038,6 +1102,13 @@ mongodb:
   arbiter:
     enabled: false
   resources: {}
+  tls:
+    enabled: true
+    replicaset:
+      existingSecrets:
+        - internal-tls
+        - internal-tls
+        - internal-tls
 
 ##
 ## RabbitMQ configuration (3rd party chart dependency)
@@ -1055,6 +1126,10 @@ rabbitmq:
     forceBoot: true
   # Authentication Details
   auth:
+    tls:
+      enabled: true
+      existingSecret: "internal-tls"
+    # Fail over to username admin if LDAP is down:
     username: admin
     # TODO: Use default random 10 character password, but need to fetch this string for use by downstream services
     password: 9jS+w1u07NbHtZke1m+jW4Cj
@@ -1085,7 +1160,9 @@ rabbitmq:
   # As RabbitMQ enabled prometheus operator monitoring by default, disable it for non-prometheus users
   metrics:
     enabled: false
-
+  tls:
+    enabled: true
+    existingSecret: "internal-tls"
 ##
 ## Redis HA configuration (3rd party chart dependency)
 ##
@@ -1121,6 +1198,13 @@ redis:
   usePassword: false
   metrics:
     enabled: false
+  tls:
+    enabled: true
+    authClients: false
+    certificatesSecret: internal-tls
+    certFilename: tls.crt
+    certKeyFilename: tls.key
+    certCAFilename: ca.crt
 
 ##
 ## Settings to be applied to all stackstorm-ha pods
@@ -1156,3 +1240,13 @@ external-dns:
   aws:
     zoneType: "public"
   domainFilters: []
+
+##
+## Image details for ghostunnel
+##
+ghostunnel:
+  image:
+    name: ghostunnel
+    repository: ghostunnel
+    tag: v1.6.0
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Continuing on from the theme in (https://github.com/StackStorm/stackstorm-k8s/pull/400) this PR is another attempt at improving the security hardening of StackStorm in `k8s`.

By default - all inter-pod communication between pods within a `k8s` deployment use non-encrypted protocols. (i.e. Between `st2` and `Mongo` / `RabbitMQ` and `Redis`, and to the internal `api`, `auth` and `stream` endpoints within `st2`)

This is fine if your security model is hard (secure) on the outside (public facing), but crunchy (insecure) on the inside (private facing) - (like an [Armadillo](https://www.youtube.com/watch?v=bqeGxMgVOHI) 😉).

However, ideally a modern approach would be zero-trust and secure communication everywhere.

This PR therefore, enables by default, Encryption/TLS everywhere*. It makes use of [cert-manager](https://cert-manager.io/) to enabled automatic generation of certificates, either using a user provided CA (to allow use of a corporate CA) or if the user already has a cert issuer setup - one can provide that.

TLS is enabled/configured globally for `st2` endpoints (`api`, `auth`, `stream`) under the `st2` block in `values.yaml`

```
  tls:
    enabled: true
    secretName: "internal-tls"
    mountPath: "/etc/ssl/internal"
    certificate_issuer:
      existing: false
      name: stackstorm-issuer
```

And then the individual endpoints can be toggled on/off under their respective blocks in `values.yaml`.

Sadly the `mongo` and `rabbitmq` TLS can't be setup from the `st2` config directly - so they're present (and have defaults configured) under their respective blocks as well.

The `st2` templates have then been updated to automatically configure all the required settings to use these certificates to enabled TLS - and the cert/key/ca are also automatically mounted to all the containers. 

Note since the `api` and `stream` endpoints don't support encryption, we have added a TLS proxy layer (using [ghostunnel](https://github.com/ghostunnel/ghostunnel)) infront of them to enable _inter_-pod encryption while allowing unencrypted communication on the _intra_-pod commuication between the `st2` component and the proxy layer.

*Note that the [OpenStack Tooz](https://github.com/openstack/tooz) library, which `st2` uses to talk to Redis, doesn't have support to configure the settings needed to enable TLS when using Sentinel - so Redis traffic is still unencrypted in this PR. However, we have an internal build of `Tooz` that adds this support, and we've also got the changes to the StackStorm helm template to support that working internally. Once we have our changes to `Tooz` merged upstream, we can provide a PR to `stackstorm-k8s` and `st2` core library to enable this support as well.