### PR TITLE
add securityContext for more containers with better fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Development
 * Fix syntax with ensure-packs-volumes-are-writable job (#403) (by @skiedude)
+* Add securityContext support to custom st2packs images, extra_hooks jobs; Also fallback to st2actionrunner securityContext for misc init container jobs and pods. (#410) (by @cognifloyd)
 
 ## v1.0.0
 * Bump to latest CircleCI orb versions (kubernetes@1.3.1 and helm@3.0.0 by @ZoeLeah)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -344,7 +344,8 @@ Merge packs and virtualenvs from st2 with those from st2packs images
     - |
       /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
       /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-  {{- with $.Values.securityContext }}
+  {{- with .securityContext | default $.Values.st2actionrunner.securityContext | default $.Values.securityContext }}
+  {{/* st2actionrunner is likely the most permissive so use that if defined. */}}
   securityContext: {{- toYaml . | nindent 8 }}
   {{- end }}
     {{- end }}
@@ -365,7 +366,8 @@ Merge packs and virtualenvs from st2 with those from st2packs images
     - |
       /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
       /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-  {{- with .Values.securityContext }}
+  {{- with .Values.st2actionrunner.securityContext | default .Values.securityContext }}
+  {{/* st2actionrunner is likely the most permissive so use that if defined. */}}
   securityContext: {{- toYaml . | nindent 8 }}
   {{- end }}
   {{- end }}
@@ -384,7 +386,8 @@ Merge packs and virtualenvs from st2 with those from st2packs images
     - '-ec'
     - |
       /bin/cp -aR /opt/stackstorm/configs/. /opt/stackstorm/configs-shared
-  {{- with .Values.securityContext }}
+  {{- with .Values.st2actionrunner.securityContext | default .Values.securityContext }}
+  {{/* st2actionrunner is likely the most permissive so use that if defined. */}}
   securityContext: {{- toYaml . | nindent 8 }}
   {{- end }}
   {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -428,7 +428,7 @@ spec:
       - name: st2web
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- with default .Values.securityContext .Values.st2web.securityContext }}
+        {{- with .Values.st2web.securityContext | default .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         ports:
@@ -515,7 +515,7 @@ spec:
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with default .Values.podSecurityContext .Values.st2client.podSecurityContext }}
+    {{- with .Values.st2client.podSecurityContext | default .Values.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2web.nodeSelector }}
@@ -1187,7 +1187,7 @@ spec:
       - name: {{ $name }}
         image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2sensorcontainer:{{ tpl ($sensor.image.tag | default $.Values.image.tag) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
-        {{- with default $.Values.securityContext $sensor.securityContext }}
+        {{- with $sensor.securityContext | default $.Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with $sensor.readinessProbe }}
@@ -1282,7 +1282,7 @@ spec:
     {{- with $.Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with default $.Values.podSecurityContext $sensor.podSecurityContext }}
+    {{- with $sensor.podSecurityContext | default $.Values.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with $sensor.nodeSelector }}
@@ -1353,7 +1353,7 @@ spec:
         image: '{{ .image.repository | default (include "stackstorm-ha.imageRepository" $) }}/{{ .image.name | default "st2actionrunner" }}:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
         {{- end }}
         imagePullPolicy: {{ .Values.st2actionrunner.image.pullPolicy | default .Values.image.pullPolicy }}
-        {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
+        {{- with .Values.st2actionrunner.securityContext | default .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         # TODO: Add liveness/readiness probes (#3)
@@ -1436,7 +1436,7 @@ spec:
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with default .Values.podSecurityContext .Values.st2actionrunner.podSecurityContext }}
+    {{- with .Values.st2actionrunner.podSecurityContext | default .Values.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2actionrunner.nodeSelector }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -515,7 +515,7 @@ spec:
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.st2client.podSecurityContext | default .Values.podSecurityContext }}
+    {{- with .Values.st2web.podSecurityContext | default .Values.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2web.nodeSelector }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1600,7 +1600,7 @@ spec:
       - name: generate-st2client-config
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- with .Values.securityContext }}
+        {{- with .Values.st2client.securityContext | default .Values.st2actionrunner.securityContext | default .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         envFrom:
@@ -1627,7 +1627,7 @@ spec:
       - name: st2client
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
+        {{- with .Values.st2client.securityContext | default .Values.st2actionrunner.securityContext | default .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         env:
@@ -1728,7 +1728,7 @@ spec:
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with default .Values.podSecurityContext .Values.st2client.podSecurityContext }}
+    {{- with .Values.st2client.podSecurityContext | default .Values.st2actionrunner.podSecurityContext | default .Values.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2client.nodeSelector }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -411,7 +411,8 @@ spec:
       - name: st2-register-content-custom-init
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- with .Values.securityContext }}
+        {{- with .Values.st2actionrunner.securityContext | default .Values.securityContext }}
+        {{/* st2actionrunner is likely the most permissive so use that if defined. */}}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         command: {{- toYaml $.Values.jobs.preRegisterContentCommand | nindent 8 }}
@@ -425,7 +426,8 @@ spec:
       - name: st2-register-content
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- with .Values.securityContext }}
+        {{- with .Values.st2actionrunner.securityContext | default .Values.securityContext }}
+        {{/* st2actionrunner is likely the most permissive so use that if defined. */}}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         command:
@@ -470,7 +472,8 @@ spec:
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.podSecurityContext }}
+    {{- with .Values.st2actionrunner.podSecurityContext | default .Values.podSecurityContext }}
+      {{/* st2actionrunner is likely the most permissive so use that if defined. */}}
       securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.jobs.nodeSelector }}
@@ -641,7 +644,7 @@ spec:
       - name: generate-st2client-config
         image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
-        {{- with $.Values.securityContext }}
+        {{- with default $.Values.st2actionrunner.securityContext | default $.Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         envFrom:
@@ -668,7 +671,7 @@ spec:
       - name: {{ $name }}
         image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
-        {{- with $.Values.securityContext }}
+        {{- with .securityContext | default $.Values.st2actionrunner.securityContext | default $.Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- if $.Values.jobs.env }}
@@ -718,7 +721,7 @@ spec:
     {{- with $.Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with $.Values.podSecurityContext }}
+    {{- with $.Values.jobs.podSecurityContext | default $.Values.st2actionrunner.podSecurityContext | default $.Values.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with $.Values.jobs.nodeSelector }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -644,7 +644,7 @@ spec:
       - name: generate-st2client-config
         image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2actionrunner:{{ tpl ($.Values.jobs.image.tag | default ($.Values.st2actionrunner.image.tag | default $.Values.image.tag)) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
-        {{- with default $.Values.st2actionrunner.securityContext | default $.Values.securityContext }}
+        {{- with $.Values.st2actionrunner.securityContext | default $.Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         envFrom:
@@ -721,7 +721,7 @@ spec:
     {{- with $.Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with $.Values.jobs.podSecurityContext | default $.Values.st2actionrunner.podSecurityContext | default $.Values.podSecurityContext }}
+    {{- with .podSecurityContext | default $.Values.st2actionrunner.podSecurityContext | default $.Values.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with $.Values.jobs.nodeSelector }}

--- a/tests/unit/security_context_test.yaml
+++ b/tests/unit/security_context_test.yaml
@@ -347,6 +347,7 @@ tests:
           - name: upgrade-warning
             hook: pre-upgrade, pre-rollback
             hook_weight: -5
+            command: ["st2", "run", "--tail", "custom_pack.warn_about_upgrade"]
             podSecurityContext: *pod_security_context_override_2
             securityContext: *security_context_override_2
 

--- a/tests/unit/security_context_test.yaml
+++ b/tests/unit/security_context_test.yaml
@@ -18,6 +18,9 @@ templates:
   - secrets_st2auth.yaml
   - secrets_st2chatops.yaml
 
+# TODO: test initContainers that use st2.packs.images[].securityContext
+#       (there is no good way to select initContainers)
+
 tests:
   - it: Deployment and Job Pods+Containers have no SecurityContext by default
     templates:
@@ -34,6 +37,7 @@ tests:
         # job-st2-apikey-load
         # job-st2-key-load
         # job-st2-register-content
+        # job-ensure-packs-volumes-are-writable
         # extra_hooks job
     set:
       st2chatops:
@@ -135,7 +139,16 @@ tests:
     template: deployments.yaml
     set:
       st2:
-        packs: { sensors: [] } # ensure only 1 sensor
+        packs:
+          sensors: [] # ensure only 1 sensor
+          #images: &st2_packs_images
+          #  - repository: index.docker.io/stackstorm
+          #    name: st2packs
+          #    tag: example
+          #    securityContext: &st2packs_security_context
+          #      capabilities:
+          #        drop: [ALL]
+          #        add: [kill, net_raw, chown, fowner]
         rbac: { enabled: true } # enable rbac job
 
       podSecurityContext: *global_pod_security_context
@@ -159,8 +172,14 @@ tests:
         securityContext: *security_context_override
 
       st2client:
-        podSecurityContext: *pod_security_context_override
-        securityContext: *security_context_override
+        podSecurityContext: &pod_security_context_override_2
+          fsGroup: 8888
+          supplementalGroups: [4444]
+        securityContext: &security_context_override_2
+          capabilities:
+            drop: [ALL]
+            add: [kill, net_raw, chown]
+
     asserts:
       - hasDocuments:
           count: 13
@@ -231,16 +250,201 @@ tests:
       # st2client pod
       - notEqual: *global_pod_security_context_assert
         documentIndex: 12
+      - notEqual: *override_pod_security_context_assert
+        documentIndex: 12
+      - equal: &override_pod_security_context_assert_2
+          path: spec.template.spec.securityContext
+          value: *pod_security_context_override_2
+        documentIndex: 12
+
+      # st2client container
+      - notEqual: *global_container0_security_context_assert
+        documentIndex: 12
+      - notEqual: *override_container0_security_context_assert
+        documentIndex: 12
+      - equal: &override_container0_security_context_assert_2
+          path: spec.template.spec.containers[0].securityContext
+          value: *security_context_override_2
+        documentIndex: 12
+      # path can only select one element, not all initContainers (if present).
+      #- notEqual: *global_initcontainers_security_context_assert
+      #  documentIndex: 12
+      #- notEqual: *override_initcontainers_security_context_assert
+      #  documentIndex: 12
+      #- equal: &override_initcontainers_security_context_assert_2
+      #    path: spec.template.spec.initContainers[].securityContext
+      #    value: *security_context_override
+      #  documentIndex: 12
+
+  - it: st2client Deployment Pod+Containers default to st2actionrunner SecurityContext overrides
+    template: deployments.yaml
+    set:
+      st2:
+        packs:
+          sensors: [] # ensure only 1 sensor
+          #images: *st2_packs_images
+        rbac: { enabled: true } # enable rbac job
+
+      podSecurityContext: *global_pod_security_context
+      securityContext: *global_security_context
+
+      st2actionrunner:
+        podSecurityContext: *pod_security_context_override
+        securityContext: *security_context_override
+
+      #st2client: no override defined
+
+    asserts:
+      - hasDocuments:
+          count: 13
+
+      # st2client pod
+      - notEqual: *global_pod_security_context_assert
+        documentIndex: 12
+      - notEqual: *override_pod_security_context_assert_2
+        documentIndex: 12
       - equal: *override_pod_security_context_assert
         documentIndex: 12
 
       # st2client container
       - notEqual: *global_container0_security_context_assert
         documentIndex: 12
+      - notEqual: *override_container0_security_context_assert_2
+        documentIndex: 12
       - equal: *override_container0_security_context_assert
         documentIndex: 12
       # path can only select one element, not all initContainers (if present).
       #- notEqual: *global_initcontainers_security_context_assert
       #  documentIndex: 12
+      #- notEqual: *override_initcontainers_security_context_assert_2
+      #  documentIndex: 12
       #- equal: *override_initcontainers_security_context_assert
       #  documentIndex: 12
+
+  # overrides for register-content job and extra_hooks job(s)
+  # document indexes: 3, 5
+
+  - it: extra_hooks Jobs Pod+Containers accept SecurityContext overrides
+    template: jobs.yaml
+    set:
+      st2:
+        packs:
+          sensors: [] # ensure only 1 sensor
+          images: []
+          volumes: *volumes_enabled
+          configs: {} # has one core.yaml config file by default (dicts get merged)
+        rbac: { enabled: true } # enable rbac job
+
+      podSecurityContext: *global_pod_security_context
+      securityContext: *global_security_context
+
+      st2actionrunner:
+        podSecurityContext: *pod_security_context_override
+        securityContext: *security_context_override
+
+      jobs:
+        extra_hooks:
+          - name: upgrade-warning
+            hook: pre-upgrade, pre-rollback
+            hook_weight: -5
+            podSecurityContext: *pod_security_context_override_2
+            securityContext: *security_context_override_2
+
+    asserts:
+      - hasDocuments:
+          count: 6
+
+      # extra_hooks job pod
+      - notEqual: *global_pod_security_context_assert
+        documentIndex: 5
+      - notEqual: *override_pod_security_context_assert
+        documentIndex: 5
+      - equal: *override_pod_security_context_assert_2
+        documentIndex: 5
+
+      # extra_hooks job container
+      - notEqual: *global_container0_security_context_assert
+        documentIndex: 5
+      - notEqual: *override_container0_security_context_assert
+        documentIndex: 5
+      - equal: *override_container0_security_context_assert_2
+        documentIndex: 5
+      # path can only select one element, not all initContainers (if present).
+      #- notEqual: *global_initcontainers_security_context_assert
+      #  documentIndex: 5
+      #- notEqual: *override_initcontainers_security_context_assert
+      #  documentIndex: 5
+      #- equal: *override_initcontainers_security_context_assert_2
+      #  documentIndex: 5
+
+  - it: register-content and extra_hooks Jobs Pod+Containers default to st2actionrunner SecurityContext overrides
+    template: jobs.yaml
+    set:
+      st2:
+        packs:
+          sensors: [] # ensure only 1 sensor
+          images: []
+          volumes: *volumes_enabled
+          configs: {} # has one core.yaml config file by default (dicts get merged)
+        rbac: { enabled: true } # enable rbac job
+
+      podSecurityContext: *global_pod_security_context
+      securityContext: *global_security_context
+
+      st2actionrunner:
+        podSecurityContext: *pod_security_context_override
+        securityContext: *security_context_override
+
+      jobs:
+        extra_hooks: *jobs_extra_hooks
+          # does not override podSecurityContext or securityContext
+
+    asserts:
+      - hasDocuments:
+          count: 6
+
+      # job-register-content pod
+      - notEqual: *global_pod_security_context_assert
+        documentIndex: 3
+      - notEqual: *override_pod_security_context_assert_2
+        documentIndex: 3
+      - equal: *override_pod_security_context_assert
+        documentIndex: 3
+
+      # job-register-content container
+      - notEqual: *global_container0_security_context_assert
+        documentIndex: 3
+      - notEqual: *override_container0_security_context_assert_2
+        documentIndex: 3
+      - equal: *override_container0_security_context_assert
+        documentIndex: 3
+      # path can only select one element, not all initContainers (if present).
+      #- notEqual: *global_initcontainers_security_context_assert
+      #  documentIndex: 3
+      #- notEqual: *override_initcontainers_security_context_assert_2
+      #  documentIndex: 3
+      #- equal: *override_initcontainers_security_context_assert
+      #  documentIndex: 3
+
+      # extra_hooks job pod
+      - notEqual: *global_pod_security_context_assert
+        documentIndex: 5
+      - notEqual: *override_pod_security_context_assert_2
+        documentIndex: 5
+      - equal: *override_pod_security_context_assert
+        documentIndex: 5
+
+      # extra_hooks job container
+      - notEqual: *global_container0_security_context_assert
+        documentIndex: 5
+      - notEqual: *override_container0_security_context_assert_2
+        documentIndex: 5
+      - equal: *override_container0_security_context_assert
+        documentIndex: 5
+      # path can only select one element, not all initContainers (if present).
+      #- notEqual: *global_initcontainers_security_context_assert
+      #  documentIndex: 5
+      #- notEqual: *override_initcontainers_security_context_assert_2
+      #  documentIndex: 5
+      #- equal: *override_initcontainers_security_context_assert
+      #  documentIndex: 5

--- a/values.yaml
+++ b/values.yaml
@@ -150,6 +150,8 @@ st2:
       #  pullPolicy: IfNotPresent
       # Optional name of the imagePullSecret if your custom packs image is hosted by a private Docker registry
       #  pullSecret: st2packs-auth
+      # Optional .securityContext override for container
+      #  securityContext:
 
     # Custom packs volumes definitions.
     #
@@ -288,7 +290,7 @@ st2:
 
 ##
 ## Default SecurityContext for pods and containers.
-## Overrides available for st2web, st2actionrunner, st2sensorcontainer, and st2client pods.
+## Overrides available for st2web, st2actionrunner, st2sensorcontainer, st2client pods, and custom packs images.
 ##
 podSecurityContext: {}
 securityContext: {}
@@ -703,7 +705,7 @@ st2actionrunner:
     attach: false
   # override the default .podSecurityContext or .securityContext here
   podSecurityContext: {}
-  securityContext: {}
+  securityContext: {} # also applies to init or jobs containers that copy/modify files
   # postStartScript is optional. It has the contents of a bash script.
   # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
   # The pod will not be marked as "running" until this script completes successfully.
@@ -984,6 +986,7 @@ jobs:
     #   hook: post-install   # required "helm.sh/hook"
     #   hook_weight: 10      # optional hook_weight (defaults to 10)
     #   resources: {}        # optional definition of resources to request
+    #   securityContext: {}  # optional definition of container securityContext override
     #   command:             # required command to run
     #     - st2
     #     - run

--- a/values.yaml
+++ b/values.yaml
@@ -986,6 +986,7 @@ jobs:
     #   hook: post-install   # required "helm.sh/hook"
     #   hook_weight: 10      # optional hook_weight (defaults to 10)
     #   resources: {}        # optional definition of resources to request
+    #   podSecurityContext: {} # optional definition of pod securityContext override
     #   securityContext: {}  # optional definition of container securityContext override
     #   command:             # required command to run
     #     - st2


### PR DESCRIPTION
This adds values to define the `securityContext` for:
- custom st2packs images
- extra_hooks jobs (container and pod)

Some of the init and jobs containers need more permissions to copy/modify files. The st2actionrunner pods are most likely to have the most permissive permissions, so default to that if the deployment/job-specific securityContext values are not defined.