### PR TITLE
Improve Deployments migration in `migrations/1.0/standardize-labels.sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Stop generating the DataStore Secret (#385) and checksum labels (#391) when existing secret provided or disabled (by @bmarick)
 * Stop generating the checksum labels for Auth Secret (#392) when existing secret provided or disabled (by @bmarick)
 * Use `image.pullPolicy` for all containers including init containers that use `image.utilityImage`. (#397) (by @jk464)
+* Improve Deployments migration in `migrations/v1.0/standardize-labels.sh` by temporarily orphaning the old ReplicaSets. (#412) (by @cognifloyd)
 
 ## v1.0.0
 * Bump to latest CircleCI orb versions (kubernetes@1.3.1 and helm@3.0.0 by @ZoeLeah)


### PR DESCRIPTION
Helm could not apply some of the 1.0.0 changes to deployments because some fields were immutable. So, this adjusts the migration script to orphan the replicasets and delete the deployments. Then when helm upgrade recreates the deployments, they will adopt the orphaned replicasets and gradually recreate both replicasets and pods using the latest spec.

It has been a long time since I wrote this, so I don't remember exactly which fields caused the issues. I adjusted this to work when migrating one of my helm-managed st2 clusters.