### PR TITLE
Add `image.entrypoint` value to support custom entrypoints like `dumb-init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Stop generating the DataStore Secret (#385) and checksum labels (#391) when existing secret provided or disabled (by @bmarick)
 * Stop generating the checksum labels for Auth Secret (#392) when existing secret provided or disabled (by @bmarick)
 * Use `image.pullPolicy` for all containers including init containers that use `image.utilityImage`. (#397) (by @jk464)
+* Add new `image.entrypoint` value to simplify using a custom entry point like `dumb-init` or `pid1` (if installed in the image). (#413) (by @cognifloyd)
 
 ## v1.0.0
 * Bump to latest CircleCI orb versions (kubernetes@1.3.1 and helm@3.0.0 by @ZoeLeah)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -182,8 +182,9 @@ Reduce duplication of the st2.*.conf volume details
 {{- end -}}
 
 {{- define "stackstorm-ha.st2-entrypoint" -}}
-- /usr/bin/dumb-init
-- '--'
+  {{- range $.Values.image.entrypoint }}
+- {{ toYaml . }}
+  {{- end }}
 {{- end -}}
 
 # Override CMD CLI parameters passed to the startup of all pods to add support for /etc/st2/st2.secrets.conf

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -181,6 +181,11 @@ Reduce duplication of the st2.*.conf volume details
 {{- end }}
 {{- end -}}
 
+{{- define "stackstorm-ha.st2-entrypoint" -}}
+- /usr/bin/dumb-init
+- '--'
+{{- end -}}
+
 # Override CMD CLI parameters passed to the startup of all pods to add support for /etc/st2/st2.secrets.conf
 {{- define "stackstorm-ha.st2-config-file-parameters" -}}
 - --config-file=/etc/st2/st2.conf

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -76,6 +76,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2auth
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2auth.env }}
@@ -203,6 +204,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2api
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2api.env }}
@@ -335,6 +337,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2stream
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2stream.env }}
@@ -580,6 +583,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2rulesengine
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2rulesengine.env }}
@@ -697,6 +701,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2timersengine
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2timersengine.env }}
@@ -804,6 +809,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2workflowengine
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2workflowengine.env }}
@@ -922,6 +928,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2scheduler
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2scheduler.env }}
@@ -1038,6 +1045,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2notifier
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2notifier.env }}
@@ -1213,6 +1221,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2sensorcontainer
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
           {{- if $one_sensor_per_pod }}{{/* only in st2.packs.sensors[] */}}
@@ -1375,6 +1384,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2actionrunner
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2actionrunner.env }}
@@ -1509,6 +1519,7 @@ spec:
         #livenessProbe:
         #readinessProbe:
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - /opt/stackstorm/st2/bin/st2garbagecollector
           {{- include "stackstorm-ha.st2-config-file-parameters" $ | nindent 10 }}
         {{- if .Values.st2garbagecollector.env }}
@@ -1690,6 +1701,7 @@ spec:
           mountPath: /post-start.sh
           subPath: post-start.sh
         command:
+          {{- include "stackstorm-ha.st2-entrypoint" $ | nindent 10 }}
           - 'bash'
           - '-ec'
           - 'while true; do sleep 999; done'

--- a/tests/unit/image_entrypoint_test.yaml
+++ b/tests/unit/image_entrypoint_test.yaml
@@ -46,23 +46,19 @@ tests:
       # document indexes: 3, 13
       # all remaining deployments do use image.entrypoint
 
-      - notEqual: &eq_custom_entrypoint_0
+      - notExists: &exists_command
+          path: spec.template.spec.containers[0].command
+        documentIndex: 3 # st2web
+      - notExists: *exists_command
+        documentIndex: 13 # st2chatops
+
+      - equal: &eq_custom_entrypoint_0
           path: spec.template.spec.containers[0].command[0]
           value: *custom_entrypoint_0
-        documentIndex: 3 # st2web
-      - notEqual: &eq_custom_entrypoint_1
+        documentIndex: 0
+      - equal: &eq_custom_entrypoint_1
           path: spec.template.spec.containers[0].command[1]
           value: *custom_entrypoint_1
-        documentIndex: 3 # st2web
-
-      - notEqual: *eq_custom_entrypoint_0
-        documentIndex: 13 # st2chatops
-      - notEqual: *eq_custom_entrypoint_1
-        documentIndex: 13 # st2chatops
-
-      - equal: *eq_custom_entrypoint_0
-        documentIndex: 0
-      - equal: *eq_custom_entrypoint_1
         documentIndex: 0
       - equal: *eq_custom_entrypoint_0
         documentIndex: 1
@@ -123,14 +119,9 @@ tests:
       - hasDocuments:
           count: 14
 
-      - notEqual: *eq_custom_entrypoint_0
+      - notExists: *exists_command
         documentIndex: 3 # st2web
-      - notEqual: *eq_custom_entrypoint_1
-        documentIndex: 3 # st2web
-
-      - notEqual: *eq_custom_entrypoint_0
-        documentIndex: 13 # st2chatops
-      - notEqual: *eq_custom_entrypoint_1
+      - notExists: *exists_command
         documentIndex: 13 # st2chatops
 
       - notEqual: *eq_custom_entrypoint_0
@@ -196,14 +187,9 @@ tests:
       - hasDocuments:
           count: 14
 
-      - notEqual: *eq_custom_entrypoint_0
+      - notExists: *exists_command
         documentIndex: 3 # st2web
-      - notEqual: *eq_custom_entrypoint_1
-        documentIndex: 3 # st2web
-
-      - notEqual: *eq_custom_entrypoint_0
-        documentIndex: 13 # st2chatops
-      - notEqual: *eq_custom_entrypoint_1
+      - notExists: *exists_command
         documentIndex: 13 # st2chatops
 
       - notEqual: *eq_custom_entrypoint_0

--- a/tests/unit/image_entrypoint_test.yaml
+++ b/tests/unit/image_entrypoint_test.yaml
@@ -46,10 +46,10 @@ tests:
       # document indexes: 3, 13
       # all remaining deployments do use image.entrypoint
 
-      - notExists: &exists_command
+      - isNull: &exists_command
           path: spec.template.spec.containers[0].command
         documentIndex: 3 # st2web
-      - notExists: *exists_command
+      - isNull: *exists_command
         documentIndex: 13 # st2chatops
 
       - equal: &eq_custom_entrypoint_0
@@ -119,9 +119,9 @@ tests:
       - hasDocuments:
           count: 14
 
-      - notExists: *exists_command
+      - isNull: *exists_command
         documentIndex: 3 # st2web
-      - notExists: *exists_command
+      - isNull: *exists_command
         documentIndex: 13 # st2chatops
 
       - notEqual: *eq_custom_entrypoint_0
@@ -187,9 +187,9 @@ tests:
       - hasDocuments:
           count: 14
 
-      - notExists: *exists_command
+      - isNull: *exists_command
         documentIndex: 3 # st2web
-      - notExists: *exists_command
+      - isNull: *exists_command
         documentIndex: 13 # st2chatops
 
       - notEqual: *eq_custom_entrypoint_0

--- a/tests/unit/image_entrypoint_test.yaml
+++ b/tests/unit/image_entrypoint_test.yaml
@@ -1,0 +1,257 @@
+---
+suite: Image Entrypoint
+templates:
+  # primary template files
+  - deployments.yaml
+
+  # included templates must also be listed
+  - configmaps_overrides.yaml
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+# relevant values:
+#   image.entrypoint
+
+tests:
+  - it: Deployments use custom image.entrypoint
+    template: deployments.yaml
+      # st2auth, st2api,
+      # st2stream, st2web,
+      # st2rulesengine, st2timersengine,
+      # st2workflowengine, st2scheduler,
+      # st2notifier, (1) st2sensorcontainer,
+      # st2actionrunner, st2garbagecollector,
+      # st2client, st2chatops
+    set:
+      image:
+        entrypoint:
+          - &custom_entrypoint_0 "/usr/bin/dumb-init"
+          - &custom_entrypoint_1 "--"
+      st2:
+        rbac: { enabled: true } # enable rbac job
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 14
+
+      # st2web and st2chatops do not use image.entrypoint
+      # document indexes: 3, 13
+      # all remaining deployments do use image.entrypoint
+
+      - notEqual: &eq_custom_entrypoint_0
+          path: spec.template.spec.containers[0].command[0]
+          value: *custom_entrypoint_0
+        documentIndex: 3 # st2web
+      - notEqual: &eq_custom_entrypoint_1
+          path: spec.template.spec.containers[0].command[1]
+          value: *custom_entrypoint_1
+        documentIndex: 3 # st2web
+
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 13 # st2chatops
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 13 # st2chatops
+
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 0
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 0
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 1
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 1
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 2
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 2
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 4
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 4
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 5
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 5
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 6
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 6
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 7
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 7
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 8
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 8
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 9
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 9
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 10
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 10
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 11
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 11
+      - equal: *eq_custom_entrypoint_0
+        documentIndex: 12
+      - equal: *eq_custom_entrypoint_1
+        documentIndex: 12
+
+  - it: Deployments use custom empty image.entrypoint
+    template: deployments.yaml
+    set:
+      # image.entrypoint defaults to []
+      # this might change in a future release
+      st2:
+        rbac: { enabled: true } # enable rbac job
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 14
+
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 3 # st2web
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 3 # st2web
+
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 13 # st2chatops
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 13 # st2chatops
+
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 0
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 0
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 1
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 1
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 2
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 2
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 4
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 4
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 5
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 5
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 6
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 6
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 7
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 7
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 8
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 8
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 9
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 9
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 10
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 10
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 11
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 11
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 12
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 12
+
+  - it: Deployments use default image.entrypoint
+    template: deployments.yaml
+    set:
+      image:
+        entrypoint: []  # explicitly empty list
+      st2:
+        rbac: { enabled: true } # enable rbac job
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 14
+
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 3 # st2web
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 3 # st2web
+
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 13 # st2chatops
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 13 # st2chatops
+
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 0
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 0
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 1
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 1
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 2
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 2
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 4
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 4
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 5
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 5
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 6
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 6
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 7
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 7
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 8
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 8
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 9
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 9
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 10
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 10
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 11
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 11
+      - notEqual: *eq_custom_entrypoint_0
+        documentIndex: 12
+      - notEqual: *eq_custom_entrypoint_1
+        documentIndex: 12
+

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,7 @@ image:
   # May be required for public docker hub due to rate limiting or any private repository.
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   #pullSecret: "your-pull-secret"
-  # Image entry point.
+  # Image entry point for st2* deployments (except st2web and st2chatops).
   # This chart replaces the entrypoint (command+args) baked into the docker images.
   # If you are have installed a custom init process (like dumb-init, pid1, tini or similar),
   # in the docker image(s) you are using, you can add that entrypoint here.

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,14 @@ image:
   # May be required for public docker hub due to rate limiting or any private repository.
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   #pullSecret: "your-pull-secret"
+  # Image entry point.
+  # This chart replaces the entrypoint (command+args) baked into the docker images.
+  # If you are have installed a custom init process (like dumb-init, pid1, tini or similar),
+  # in the docker image(s) you are using, you can add that entrypoint here.
+  entrypoint: []
+    # For example you could add dumb-init like this (dumb-init must be present in the image).
+    #- "/usr/bin/dumb-init"
+    #- "--"
 
 ##
 ## local cluster domain suffix to enable fqdn lookups for redis, mongo


### PR DESCRIPTION
My actionrunner pods have exhausted the pid space due to zombie processes. So, we need something to cleanup those zombies. `dumb-init` does that. See:
- https://github.com/Yelp/dumb-init
- https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html

Installing `dumb-init`, `pid1`, or some other entrypoint app requires installing it in the docker image (ie we have to update the docker images). But, the chart also needs to support the older images that don't include it. So, hard-coding the entry-point is not an option. Once we update the docker images to install an init process, we can update the default value in the chart to include that init process, but still allow people using an older image to set that value to `[]` and still use the chart.

Also, we would still need to include the init command in the chart somehow (not just in the docker image's `ENTRYPOINT`) because the chart overwrites the command baked into the images to pass additional config files. So, making this a value seems to be a good path forward.