### PR TITLE
Refactor unit tests to support unittests v0.4.4

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -35,7 +35,7 @@ jobs:
         # We should periodically check to see if another fork has taken over maintenance,
         # as the de-facto "best" fork has changed several times over the years.
         run: |
-          helm plugin install https://github.com/quintush/helm-unittest --version v0.2.11
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git  --version v0.4.4
 
       - name: Install chart dependencies
         run: |
@@ -44,4 +44,4 @@ jobs:
       - name: Run helm-unittest
         # by default looks for tests/*_test.yaml
         run: |
-          helm unittest --color --helm3 -f 'tests/unit/*_test.yaml' .
+          helm unittest --color -f 'tests/unit/*_test.yaml' .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Development
+* Updated our tests/unit to support newer versions of `unittests` - for now bumping to `v0.4.4` as `v0.5.0` has a bug that impacts us (see helm-unittest/helm-unittest#329), but testing around the bug shows `v0.5.x` should also "just work" (#414) (by @jk464)
 
 ## v1.1.0
 * Fix syntax with ensure-packs-volumes-are-writable job (#403, #411) (by @skiedude)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -38,8 +38,8 @@ spec:
           {{- toYaml .Values.st2auth.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -177,8 +177,8 @@ spec:
           {{- toYaml .Values.st2api.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.images }}
@@ -316,8 +316,8 @@ spec:
           {{- toYaml .Values.st2stream.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -426,8 +426,8 @@ spec:
           {{- toYaml .Values.st2web.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.st2web.terminationGracePeriodSeconds | default 30 }}
@@ -565,8 +565,8 @@ spec:
           {{- toYaml .Values.st2rulesengine.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -683,8 +683,8 @@ spec:
           {{- toYaml .Values.st2timersengine.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -791,8 +791,8 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.st2workflowengine.terminationGracePeriodSeconds | default 300 }}
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -910,8 +910,8 @@ spec:
           {{- toYaml .Values.st2scheduler.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -1027,8 +1027,8 @@ spec:
           {{- toYaml .Values.st2notifier.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -1173,8 +1173,8 @@ spec:
           {{- toYaml $sensor.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if $.Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ $.Values.image.pullSecret }}
       {{- end }}
       {{- if $.Values.st2.packs.images }}
@@ -1354,8 +1354,8 @@ spec:
       hostAliases:
         {{- toYaml .Values.st2actionrunner.hostAliases | nindent 8 }}
       {{- end }}
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.images }}
@@ -1501,8 +1501,8 @@ spec:
           {{- toYaml .Values.st2garbagecollector.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -1615,11 +1615,11 @@ spec:
           {{- toYaml .Values.st2client.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.st2.packs.images }}
         {{- include "stackstorm-ha.packs-pullSecrets" . | nindent 6 }}
       {{- end }}
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -25,8 +25,8 @@ spec:
           {{- toYaml .Values.jobs.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
@@ -127,8 +127,8 @@ spec:
           {{- toYaml .Values.jobs.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -266,8 +266,8 @@ spec:
           {{- toYaml .Values.jobs.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
@@ -398,8 +398,8 @@ spec:
           {{- toYaml .Values.jobs.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       {{- if $.Values.st2.packs.images -}}
@@ -512,8 +512,8 @@ spec:
         {{- toYaml $.Values.jobs.annotations | nindent 8 }}
       {{- end }}
     spec:
-      imagePullSecrets:
       {{- if $.Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ $.Values.image.pullSecret }}
       {{- end }}
       initContainers: []
@@ -633,8 +633,8 @@ spec:
           {{- toYaml $.Values.jobs.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if $.Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ $.Values.image.pullSecret }}
       {{- end }}
       {{- if $.Values.st2.packs.images -}}

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,14 +4,14 @@ This directory contains Helm chart unit and integration tests (under `tests/unit
 
 ## Unit tests
 
-Unit tests (`tests/unit/*_test.yaml`) use [`helm-unittest`](https://github.com/quintush/helm-unittest).
+Unit tests (`tests/unit/*_test.yaml`) use [`helm-unittest`](https://github.com/helm-unittest/helm-unittest).
 `helm-unittest` uses a yaml-based test file to ensure that the templates generate expected features.
 For example, they can ensure that custom annotations are applied consistently to all of the deployments.
 Unit tests do not require a running kubernetes cluster.
 
 Before running unit tests, install the `helm-unittest` plugin and ensure you have sub-charts installed:
 ```
-helm plugin install https://github.com/quintush/helm-unittest
+$ helm plugin install https://github.com/helm-unittest/helm-unittest.git
 helm dependency update
 ```
 
@@ -22,7 +22,7 @@ helm unittest --helm3 -f 'tests/unit/*_test.yaml' .
 
 > Note! If you need to add unit tests, file names should follow this pattern: `tests/unit/name_your_test.yaml`
 
-See https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md for details on writing unit tests.
+See https://github.com/helm-unittest/helm-unittest/blob/master/DOCUMENT.md for details on writing unit tests.
 
 ## Integration tests
 

--- a/tests/unit/custom_annotations_test.yaml
+++ b/tests/unit/custom_annotations_test.yaml
@@ -31,7 +31,7 @@ tests:
           foo: bar
           answer: "42"
     asserts: &annotations_asserts
-      - isNotNull:
+      - exists:
           path: metadata.annotations
       - equal:
           path: metadata.annotations.foo
@@ -125,7 +125,7 @@ tests:
           # st2client, st2chatops
 
       # deployment annotations
-      - isNotNull:
+      - exists:
           path: metadata.annotations
       - equal:
           path: metadata.annotations.foo
@@ -135,7 +135,7 @@ tests:
           value: "42"
 
       # pod annotations
-      - isNotNull:
+      - exists:
           path: spec.template.metadata.annotations
       - equal:
           path: spec.template.metadata.annotations.foo
@@ -188,7 +188,7 @@ tests:
           # extra_hooks job
 
       # job annotations
-      - isNotNull:
+      - exists:
           path: metadata.annotations
       - equal:
           path: metadata.annotations.foo
@@ -198,7 +198,7 @@ tests:
           value: "42"
 
       # pod annotations
-      - isNotNull:
+      - exists:
           path: spec.template.metadata.annotations
       - equal:
           path: spec.template.metadata.annotations.foo

--- a/tests/unit/dns_test.yaml
+++ b/tests/unit/dns_test.yaml
@@ -51,9 +51,9 @@ tests:
             hook_weight: -5
             command: ["st2", "run", "--tail", "custom_pack.warn_about_upgrade"]
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.dnsPolicy
-      - isNull:
+      - notExists:
           path: spec.template.spec.dnsConfig
 
   - it: Deployments and Jobs accept custom dnsPolicy or dnsConfig

--- a/tests/unit/env_test.yaml
+++ b/tests/unit/env_test.yaml
@@ -34,32 +34,32 @@ tests:
             - name: ST2CLIENT
               value: "1"
         documentIndex: 12
-      - isNull: &is_null_env
+      - notExists: &is_null_env
           path: spec.template.spec.containers[0].env
         documentIndex: 0
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 1
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 2
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 3
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 4
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 5
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 6
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 7
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 8
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 9
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 10
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 11
-      - isNull: *is_null_env
+      - notExists: *is_null_env
         documentIndex: 13
 
   - it: Jobs default to no env
@@ -76,7 +76,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 5
-      - isNull: *is_null_env
+      - notExists: *is_null_env
 
   - it: Deployments accept custom env
     template: deployments.yaml
@@ -177,10 +177,10 @@ tests:
       - contains: *contains_st2_urls
         documentIndex: 2
 
-      - isNull: &is_null_envFrom
+      - notExists: &is_null_envFrom
           path: spec.template.spec.containers[0].envFrom
         documentIndex: 0
-      - isNull: *is_null_envFrom
+      - notExists: *is_null_envFrom
         documentIndex: 3
 
   - it: Deployments support envFromSecrets (st2actionrunner, st2sensorcontainer, and st2client)

--- a/tests/unit/image_entrypoint_test.yaml
+++ b/tests/unit/image_entrypoint_test.yaml
@@ -46,10 +46,10 @@ tests:
       # document indexes: 3, 13
       # all remaining deployments do use image.entrypoint
 
-      - isNull: &exists_command
+      - notExists: &exists_command
           path: spec.template.spec.containers[0].command
         documentIndex: 3 # st2web
-      - isNull: *exists_command
+      - notExists: *exists_command
         documentIndex: 13 # st2chatops
 
       - equal: &eq_custom_entrypoint_0
@@ -119,9 +119,9 @@ tests:
       - hasDocuments:
           count: 14
 
-      - isNull: *exists_command
+      - notExists: *exists_command
         documentIndex: 3 # st2web
-      - isNull: *exists_command
+      - notExists: *exists_command
         documentIndex: 13 # st2chatops
 
       - notEqual: *eq_custom_entrypoint_0
@@ -187,9 +187,9 @@ tests:
       - hasDocuments:
           count: 14
 
-      - isNull: *exists_command
+      - notExists: *exists_command
         documentIndex: 3 # st2web
-      - isNull: *exists_command
+      - notExists: *exists_command
         documentIndex: 13 # st2chatops
 
       - notEqual: *eq_custom_entrypoint_0

--- a/tests/unit/image_pull_test.yaml
+++ b/tests/unit/image_pull_test.yaml
@@ -67,7 +67,7 @@ tests:
             hook_weight: -5
             command: ["st2", "run", "--tail", "custom_pack.warn_about_upgrade"]
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.imagePullSecrets
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
@@ -202,7 +202,7 @@ tests:
       serviceAccount:
         create: true
     asserts:
-      - isNull:
+      - notExists:
           path: imagePullSecrets
 
   - it: ServiceAccount accepts custom imagePullSecret

--- a/tests/unit/labels_test.yaml
+++ b/tests/unit/labels_test.yaml
@@ -54,58 +54,58 @@ tests:
       #   metdata.labels.[app.kubernetes.io/name]
       #   spec.selector.matchLabels.[app.kubernetes.io/name]
       #   spec.template.metadata.labels.[app.kubernetes.io/name]
-      # So, we use isNotNull instead.
+      # So, we use exists instead.
       # see: https://github.com/quintush/helm-unittest/issues/122
-      - isNotNull:
-          path: metadata.labels.[app.kubernetes.io/name]
-      - isNotNull:
-          path: spec.selector.matchLabels.[app.kubernetes.io/name]
-      - isNotNull:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+      - exists:
+          path: metadata.labels["app.kubernetes.io/name"]
+      - exists:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+      - exists:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
 
       - equal: &metadata_labels_instance
-          path: metadata.labels.[app.kubernetes.io/instance]
+          path: metadata.labels["app.kubernetes.io/instance"]
           value: some-release-name
       - equal:
-          path: spec.selector.matchLabels.[app.kubernetes.io/instance]
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
           value: some-release-name
       - equal: &spec_template_metadata_labels_instance
-          path: spec.template.metadata.labels.[app.kubernetes.io/instance]
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
           value: some-release-name
 
       - matchRegex: &regex_metadata_labels_component_backend_or_frontend
-          path: metadata.labels.[app.kubernetes.io/component]
+          path: metadata.labels["app.kubernetes.io/component"]
           pattern: ^(backend|frontend)$
       - matchRegex: &regex_spec_template_metadata_labels_component_backend_or_frontend
-          path: spec.template.metadata.labels.[app.kubernetes.io/component]
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
           pattern: ^(backend|frontend)$
 
       - equal: &metadata_labels_part_of
-          path: metadata.labels.[app.kubernetes.io/part-of]
+          path: metadata.labels["app.kubernetes.io/part-of"]
           value: stackstorm
       - equal: &spec_template_metadata_labels_part_of
-          path: spec.template.metadata.labels.[app.kubernetes.io/part-of]
+          path: spec.template.metadata.labels["app.kubernetes.io/part-of"]
           value: stackstorm
 
       - equal: &metadata_labels_app_version
-          path: metadata.labels.[app.kubernetes.io/version]
+          path: metadata.labels["app.kubernetes.io/version"]
           value: *appVersion
       - equal: &spec_template_metadata_labels_app_version
-          path: spec.template.metadata.labels.[app.kubernetes.io/version]
+          path: spec.template.metadata.labels["app.kubernetes.io/version"]
           value: *appVersion
 
       - equal: &metadata_labels_chart
-          path: metadata.labels.[helm.sh/chart]
+          path: metadata.labels["helm.sh/chart"]
           value: stackstorm-ha-1.0.999
       - equal: &spec_template_metadata_labels_chart
-          path: spec.template.metadata.labels.[helm.sh/chart]
+          path: spec.template.metadata.labels["helm.sh/chart"]
           value: stackstorm-ha-1.0.999
 
       - equal: &metadata_labels_managed_by
-          path: metadata.labels.[app.kubernetes.io/managed-by]
+          path: metadata.labels["app.kubernetes.io/managed-by"]
           value: Helm
       - equal: &spec_template_metadata_labels_managed_by
-          path: spec.template.metadata.labels.[app.kubernetes.io/managed-by]
+          path: spec.template.metadata.labels["app.kubernetes.io/managed-by"]
           value: Helm
 
   - it: Jobs+Pods have requried labels
@@ -154,19 +154,19 @@ tests:
       # like deployments each of these should be the same:
       #   metdata.labels.[app.kubernetes.io/name]
       #   spec.template.metadata.labels.[app.kubernetes.io/name]
-      - isNotNull:
-          path: metadata.labels.[app.kubernetes.io/name]
-      - isNotNull:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+      - exists:
+          path: metadata.labels["app.kubernetes.io/name"]
+      - exists:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
 
       - equal: *metadata_labels_instance
       - equal: *spec_template_metadata_labels_instance
 
       - matchRegex:
-          path: metadata.labels.[app.kubernetes.io/component]
+          path: metadata.labels["app.kubernetes.io/component"]
           pattern: ^(backend|tests)$
       - matchRegex:
-          path: spec.template.metadata.labels.[app.kubernetes.io/component]
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
           pattern: ^(backend|tests)$
 
       - equal: *metadata_labels_part_of
@@ -192,8 +192,8 @@ tests:
           count: 5
           # st2auth, st2api, st2stream, st2web, st2chatops
 
-      - isNotNull:
-          path: metadata.labels.[app.kubernetes.io/name]
+      - exists:
+          path: metadata.labels["app.kubernetes.io/name"]
       - equal: *metadata_labels_instance
       - matchRegex: *regex_metadata_labels_component_backend_or_frontend
       - equal: *metadata_labels_part_of
@@ -211,11 +211,11 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: stackstorm-ha
       - equal: *metadata_labels_instance
       - equal: &metadata_labels_component_backend
-          path: metadata.labels.[app.kubernetes.io/component]
+          path: metadata.labels["app.kubernetes.io/component"]
           value: backend
       - equal: *metadata_labels_part_of
       - equal: *metadata_labels_app_version
@@ -231,7 +231,7 @@ tests:
           foo: bar
           answer: "42"
     asserts:
-      - isNotNull:
+      - exists:
           path: metadata.labels
       - equal:
           path: metadata.labels.foo
@@ -253,11 +253,11 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: ingress
       - equal: *metadata_labels_instance
       - equal:
-          path: metadata.labels.[app.kubernetes.io/component]
+          path: metadata.labels["app.kubernetes.io/component"]
           value: frontend
       - equal: *metadata_labels_part_of
       - equal: *metadata_labels_app_version
@@ -284,7 +284,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal: &metadata_labels_app_eq_st2
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2
       - equal: *metadata_labels_instance
       - equal: *metadata_labels_component_backend
@@ -323,7 +323,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2chatops
       - equal: *metadata_labels_instance
       - equal: *metadata_labels_component_backend
@@ -347,11 +347,11 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2 # should this be st2web?
       - equal: *metadata_labels_instance
       - equal:
-          path: metadata.labels.[app.kubernetes.io/component]
+          path: metadata.labels["app.kubernetes.io/component"]
           value: backend # should this be frontend?
       - equal: *metadata_labels_part_of
       - equal: *metadata_labels_app_version

--- a/tests/unit/placement_test.yaml
+++ b/tests/unit/placement_test.yaml
@@ -65,11 +65,11 @@ tests:
             hook_weight: -5
             command: ["st2", "run", "--tail", "custom_pack.warn_about_upgrade"]
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.nodeSelector
-      - isNull:
+      - notExists:
           path: spec.template.spec.tolerations
-      - isNull:
+      - notExists:
           path: spec.template.spec.affinity
 
   - it: Deployments and Jobs accept custom placement

--- a/tests/unit/post_start_script_test.yaml
+++ b/tests/unit/post_start_script_test.yaml
@@ -31,10 +31,10 @@ tests:
           of: ConfigMap
       - isAPIVersion:
           of: v1
-      - isNotEmpty:
-          path: data.[post-start.sh]
+      - isNotNullOrEmpty:
+          path: data["post-start.sh"]
       - equal:
-          path: data.[post-start.sh]
+          path: data["post-start.sh"]
           value: |
             #!/bin/bash
             mkdir -p /home/yelnats/.ssh
@@ -84,10 +84,10 @@ tests:
           of: ConfigMap
       - isAPIVersion:
           of: v1
-      - isNotEmpty:
-          path: data.[post-start.sh]
+      - isNotNullOrEmpty:
+          path: data["post-start.sh"]
       - matchRegex:
-          path: data.[post-start.sh]
+          path: data["post-start.sh"]
           # (?m) = multi-line mode: ^ and $ match begin/end line in addition to begin/end text
           # (?s) = let . match \n
           # .*? = any character zero or more times, prefer fewer
@@ -106,8 +106,8 @@ tests:
 
       # st2actionrunner and st2client do not have checksum annotations
       # (even though they probably should)
-      - isNull: &assert_checksum
-          path: spec.template.metadata.annotations.[checksum/post-start-script]
+      - notExists: &assert_checksum
+          path: spec.template.metadata.annotations["checksum/post-start-script"]
 
       # only st2actionrunner and st2client have default postStart scripts
       - equal: &assert_lifecycle
@@ -119,30 +119,30 @@ tests:
       - equal: *assert_lifecycle
         documentIndex: 12
 
-      - isNull: &assert_null_lifecycle
+      - notExists: &assert_null_lifecycle
           path: spec.template.spec.containers[0].lifecycle
         documentIndex: 0
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 1
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 2
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 3
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 4
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 5
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 6
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 7
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 8
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 9
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 11
-      - isNull: *assert_null_lifecycle
+      - notExists: *assert_null_lifecycle
         documentIndex: 13
 
       - contains: &assert_volume_mount
@@ -177,10 +177,10 @@ tests:
         documentIndex: 11
 
       # st2web and st2chatops have no volumes (and can be null)
-      - isEmpty:
+      - isNullOrEmpty:
           path: spec.template.spec.containers[0].volumeMounts
         documentIndex: 3
-      - isEmpty:
+      - isNullOrEmpty:
           path: spec.template.spec.containers[0].volumeMounts
         documentIndex: 13
 
@@ -217,10 +217,10 @@ tests:
       - notContains: *assert_volume
         documentIndex: 11
 
-      - isEmpty:
+      - isNullOrEmpty:
           path: spec.template.spec.volumes
         documentIndex: 3
-      - isEmpty:
+      - isNullOrEmpty:
           path: spec.template.spec.volumes
         documentIndex: 13
 
@@ -263,7 +263,7 @@ tests:
       - hasDocuments:
           count: 14
 
-      - isNotEmpty: *assert_checksum
+      - isNotNullOrEmpty: *assert_checksum
       - equal: *assert_lifecycle
       - contains: *assert_volume_mount
       - contains: *assert_volume

--- a/tests/unit/resources_test.yaml
+++ b/tests/unit/resources_test.yaml
@@ -30,13 +30,13 @@ tests:
           count: 14
 
       # only st2web defines limits for now
-      - isNotEmpty:
+      - isNotNullOrEmpty:
           path: spec.template.spec.containers[0].resources.limits.memory
         documentIndex: 3
 
-      - isNotEmpty:
+      - isNotNullOrEmpty:
           path: spec.template.spec.containers[0].resources.requests.memory
-      - isNotEmpty:
+      - isNotNullOrEmpty:
           path: spec.template.spec.containers[0].resources.requests.cpu
 
   - it: Deployments accept custom resources (except st2client)

--- a/tests/unit/secrets_test.yaml
+++ b/tests/unit/secrets_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      - isNotEmpty:
+      - isNotNullOrEmpty:
           path: data.ST2_AUTH_PASSWORD
         documentIndex: 0
       - equal:
@@ -124,7 +124,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      - isNotEmpty:
+      - isNotNullOrEmpty:
           path: data.datastore_crypto_key
         documentIndex: 0
 

--- a/tests/unit/security_context_test.yaml
+++ b/tests/unit/security_context_test.yaml
@@ -74,13 +74,13 @@ tests:
 
     asserts:
       # pod
-      - isNull:
+      - notExists:
           path: spec.template.spec.securityContext
       # container
-      - isNull:
+      - notExists:
           path: "spec.template.spec.containers[0].securityContext"
       # path can only select one element, not all initContainers (if present).
-      #- isNull:
+      #- notExists:
       #    path: 'spec.template.spec.initContainers[].securityContext'
 
   - it: Deployment and Job Pods+Containers use same SecurityContext when defined

--- a/tests/unit/service_account_test.yaml
+++ b/tests/unit/service_account_test.yaml
@@ -52,7 +52,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 14
-      - isNull:
+      - notExists:
           path: spec.template.spec.serviceAccountName
 
   - it: Deployments can attach ServiceAccount with default name (except st2client)
@@ -92,7 +92,7 @@ tests:
       - hasDocuments:
           count: 14
       # st2client does not allow attaching serviceAccount
-      - isNull:
+      - notExists:
           path: spec.template.spec.serviceAccountName
         documentIndex: 12
 
@@ -165,7 +165,7 @@ tests:
       - hasDocuments:
           count: 14
       # st2client does not allow attaching serviceAccount
-      - isNull:
+      - notExists:
           path: spec.template.spec.serviceAccountName
         documentIndex: 12
 

--- a/tests/unit/services_test.yaml
+++ b/tests/unit/services_test.yaml
@@ -12,7 +12,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 4
-      - isNull:
+      - notExists:
           path: spec.externalName
 
   - it: st2web, st2auth, st2api, st2stream should work with externalName if type is ExternalName

--- a/tests/unit/st2sensors_test.yaml
+++ b/tests/unit/st2sensors_test.yaml
@@ -37,17 +37,17 @@ tests:
         documentIndex: *first_sensor_doc
 
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer
         documentIndex: *first_sensor_doc
 
       - equal:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer
         documentIndex: *first_sensor_doc
 
       - equal:
-          path: spec.selector.matchLabels.[app.kubernetes.io/name]
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: st2sensorcontainer
         documentIndex: *first_sensor_doc
 
@@ -129,41 +129,41 @@ tests:
         documentIndex: *third_sensor_doc
 
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-foo
         documentIndex: *first_sensor_doc
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-bar
         documentIndex: *second_sensor_doc
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-baz
         documentIndex: *third_sensor_doc
 
       - equal:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-foo
         documentIndex: *first_sensor_doc
       - equal:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-bar
         documentIndex: *second_sensor_doc
       - equal:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-baz
         documentIndex: *third_sensor_doc
 
       - equal:
-          path: spec.selector.matchLabels.[app.kubernetes.io/name]
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: st2sensorcontainer-foo
         documentIndex: *first_sensor_doc
       - equal:
-          path: spec.selector.matchLabels.[app.kubernetes.io/name]
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: st2sensorcontainer-bar
         documentIndex: *second_sensor_doc
       - equal:
-          path: spec.selector.matchLabels.[app.kubernetes.io/name]
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: st2sensorcontainer-baz
         documentIndex: *third_sensor_doc
 
@@ -293,41 +293,41 @@ tests:
         documentIndex: *third_sensor_doc
 
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-0
         documentIndex: *first_sensor_doc
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-1
         documentIndex: *second_sensor_doc
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-2
         documentIndex: *third_sensor_doc
 
       - equal:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-0
         documentIndex: *first_sensor_doc
       - equal:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-1
         documentIndex: *second_sensor_doc
       - equal:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: st2sensorcontainer-2
         documentIndex: *third_sensor_doc
 
       - equal:
-          path: spec.selector.matchLabels.[app.kubernetes.io/name]
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: st2sensorcontainer-0
         documentIndex: *first_sensor_doc
       - equal:
-          path: spec.selector.matchLabels.[app.kubernetes.io/name]
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: st2sensorcontainer-1
         documentIndex: *second_sensor_doc
       - equal:
-          path: spec.selector.matchLabels.[app.kubernetes.io/name]
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: st2sensorcontainer-2
         documentIndex: *third_sensor_doc
 


### PR DESCRIPTION
Implements #414 

Updated our `tests/unit` to support newer versions of `unittests` - for now bumping to `v0.4.4` as `v0.5.0` has a bug that impacts us (see https://github.com/helm-unittest/helm-unittest/issues/329)*

Changes required:

* `v0.3.0` of `unittests` adds `jsonPath` which required updating our `path` references to use a `jq` style compatible syntax
```diff
@@ -57,55 +57,55 @@ tests:
       # So, we use isNotNull instead.
       # see: https://github.com/quintush/helm-unittest/issues/122
       - isNotNull:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
       - isNotNull:
```
* `isNull` changed behavior, such that if the path _exists_ but has an "empty" value - the assertion now fails, i.e. the below `k8s` definition _doesn't_ pass (when it did before), since having empty `keys` doesn't do anything functionally when applied to `k8s`, and in my opinion atleast, looks displeasing/confusing - I fixed up the `helm` templates to not produce empty `imagePullSecrets` if nothing is being set - fixing the test again.
```diff
@@ -38,8 +38,8 @@ spec:
           {{- toYaml .Values.st2auth.annotations | nindent 8 }}
         {{- end }}
     spec:
-      imagePullSecrets:
       {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
...
```
* Some assertions have been renamed as of `v0.3.1` (including `isNull`, which seems to have also been when the aforementioned behavior change was introduced), other that the above issue, nothing else behaviorally seems to have changed and the old names still work - however to ensure we're future proofed in-case they are removed (in the docs atleast `isNull` and `isNotNull` are mentioned to be "deprecated", I've update the following assertions:
    * `isNotNull` with `exists`
    * `isNull` with `notExists`
    * `isEmpty` with `isNullOrEmpty`
    * `isNotEmpty` with `isNotNullOrEmpty`

With those changes, our tests now work on `v0.4.4` (and should work on `v0.5.x` once the previously mentioned bug is fixed)

The pipeline also has been updated to use `v0.4.4`

----------------------------------------------------
* Note however, testing with the broken test confirms that our tests are otherwise compatible with `v0.5.0` so once we have a fixed `v0.5.x` version we'll be able to bump to that with hopefully no further changes.