### PR TITLE
Don't preserve ownership when copying pack contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Stop generating the checksum labels for Auth Secret (#392) when existing secret provided or disabled (by @bmarick)
 * Use `image.pullPolicy` for all containers including init containers that use `image.utilityImage`. (#397) (by @jk464)
 * Use `rsync` to copy pack contents when available, falling back to `cp`. (#414) (by @cognifloyd)
+* Support non-root container environments when copying pack contents (#414) (by @Stealthii)
 
 ## v1.0.0
 * Bump to latest CircleCI orb versions (kubernetes@1.3.1 and helm@3.0.0 by @ZoeLeah)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -344,12 +344,12 @@ Merge packs and virtualenvs from st2 with those from st2packs images
     - 'sh'
     - '-ec'
     - >
-      if command rsync; then
-        rsync -a /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-        rsync -a /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared;
+      if hash rsync 2>/dev/null; then
+        rsync -rlptD /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
+        rsync -rlptD /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared;
       else
-        /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-        /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared;
+        cp -P --preserve=mode,timestamps,links,xattr /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
+        cp -P --preserve=mode,timestamps,links,xattr /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared;
       fi
   {{- with .securityContext | default $.Values.st2actionrunner.securityContext | default $.Values.securityContext }}
   {{/* st2actionrunner is likely the most permissive so use that if defined. */}}
@@ -371,12 +371,12 @@ Merge packs and virtualenvs from st2 with those from st2packs images
     - 'sh'
     - '-ec'
     - >
-      if command rsync; then
-        rsync -a /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-        rsync -a /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared;
+      if hash rsync 2>/dev/null; then
+        rsync -rlptD /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
+        rsync -rlptD /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared;
       else
-        /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-        /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+        cp -P --preserve=mode,timestamps,links,xattr /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
+        cp -P --preserve=mode,timestamps,links,xattr /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       fi
   {{- with .Values.st2actionrunner.securityContext | default .Values.securityContext }}
   {{/* st2actionrunner is likely the most permissive so use that if defined. */}}
@@ -397,10 +397,10 @@ Merge packs and virtualenvs from st2 with those from st2packs images
     - 'sh'
     - '-ec'
     - >
-      if command rsync; then
-        rsync -a /opt/stackstorm/configs/. /opt/stackstorm/configs-shared;
+      if hash rsync 2>/dev/null; then
+        rsync -rlptD /opt/stackstorm/configs/. /opt/stackstorm/configs-shared;
       else
-        /bin/cp -aR /opt/stackstorm/configs/. /opt/stackstorm/configs-shared;
+        cp -P --preserve=mode,timestamps,links,xattr /opt/stackstorm/configs/. /opt/stackstorm/configs-shared;
       fi
   {{- with .Values.st2actionrunner.securityContext | default .Values.securityContext }}
   {{/* st2actionrunner is likely the most permissive so use that if defined. */}}


### PR DESCRIPTION
This change aims to preserve file attributes when copying via rsync or cp, without ownership to enable environments where containers are ran without root privileges.