### PR TITLE
Migrate to kubeconform for k8s linting, as kubeval is now deprecated

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -50,6 +50,15 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
+      - name: Install kubeconform-helm
+        run: |
+          helm plugin install https://github.com/jtyr/kubeconform-helm  --version v0.1.17
+
+      - name: Update stackstorm-ha chart dependencies
+        run: |
+          set -x
+          helm dependency update
+
       - name: Cache community
         id: cache-community
         uses: actions/cache@v3
@@ -57,7 +66,6 @@ jobs:
           path: community
           key: ${{ runner.os }}-community-${{ hashFiles('conf/**', 'templates/**', 'Chart.yaml', 'values.yaml') }}
 
-      - name: Kubernetes kubeval lint
-        uses: instrumenta/kubeval-action@master
-        with:
-          files: community
+      - name: Kubernetes kubeconform-helm Lint
+        run: |
+          helm kubeconform .

--- a/.kubeconform
+++ b/.kubeconform
@@ -1,0 +1,8 @@
+# Command line options that can be set multiple times can be defined as an array
+schema-location:
+  - default
+  - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
+# Command line options that can be specified without a value must have boolean
+# value in the config file
+summary: true
+verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Development
 * Updated our tests/unit to support `unittests` v0.5.1 (#414, #421) (by @jk464)
+* Migrate to kubeconform for k8s linting, as kubeval is now deprecated (#420) (by @jk464)
 
 ## v1.1.0
 * Fix syntax with ensure-packs-volumes-are-writable job (#403, #411) (by @skiedude)


### PR DESCRIPTION
As per https://github.com/instrumenta/kubeval/blob/master/README.md - `kubeval` is deprecated, and the recommended replacement is [kubeconform](https://github.com/yannh/kubeconform).

This PR replaces our use of `kubeval` in the CI `k8s-lint` step with `kubeconform`.

Implementation is done using the `helm plugin` provided here https://github.com/jtyr/kubeconform-helm.

Justification for moving, aside from the deprecation, is the likes of https://github.com/StackStorm/stackstorm-k8s/pull/401 - where we could potentially add the use of 3rd party `k8s` modules(?), like `cert-manager`. 

`kubeconform` makes it very easy to validate these 3rd party additions by simply passing  `https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json` as a schema location