### PR TITLE
Bump unittests to v0.5.1

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -35,7 +35,7 @@ jobs:
         # We should periodically check to see if another fork has taken over maintenance,
         # as the de-facto "best" fork has changed several times over the years.
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git  --version v0.4.4
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git  --version v0.5.1
 
       - name: Install chart dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Development
-* Updated our tests/unit to support newer versions of `unittests` - for now bumping to `v0.4.4` as `v0.5.0` has a bug that impacts us (see helm-unittest/helm-unittest#329), but testing around the bug shows `v0.5.x` should also "just work" (#414) (by @jk464)
+* Updated our tests/unit to support `unittests` v0.5.1 (#414, #421) (by @jk464)
 
 ## v1.1.0
 * Fix syntax with ensure-packs-volumes-are-writable job (#403, #411) (by @skiedude)

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ Unit tests do not require a running kubernetes cluster.
 
 Before running unit tests, install the `helm-unittest` plugin and ensure you have sub-charts installed:
 ```
-$ helm plugin install https://github.com/helm-unittest/helm-unittest.git
+helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v0.5.1
 helm dependency update
 ```
 


### PR DESCRIPTION
[Good News, Everyone!](https://www.youtube.com/watch?v=g8IVI0sZ6F8&t=4s).

`unittests` released `v0.5.1` which fixes the critical bug preventing us from upgrading to `v0.5.0` in #414 

This PR simply just bumps us to `v0.5.1` as it just works out of the box.